### PR TITLE
bounded<...>::operator() missing const

### DIFF
--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -95,7 +95,7 @@ namespace type_safe
             }
 
             template <typename U>
-            bool operator()(const U& u)
+            bool operator()(const U& u) const
             {
                 return lower_(u) && upper_(u);
             }

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -78,7 +78,7 @@ namespace type_safe
 
         /// A `Constraint` for the [type_safe::constrained_type<T, Constraint, Verifier>]().
         /// A value is valid if it is between two given bounds,
-        /// `LowerInclusive`/`UpperInclusive` control whether the lower/upper bound itself is valid to.
+        /// `LowerInclusive`/`UpperInclusive` control whether the lower/upper bound itself is valid too.
         template <typename T, bool LowerInclusive, bool UpperInclusive>
         class bounded
         {


### PR DESCRIPTION
`constrained_type<...>::verify()` uses its `constraint_predicate` through a const path, attempting to call its non-const `operator()`, resulting in a hard-error. This PR fixes this by marking said operator `const`.

A minimal, failing example follows.
```C++
#include <type_safe/bounded_type.hpp>

int main()
{
    type_safe::make_bounded(0,0,0);
}
```