### PR TITLE
Stateless `bounded` constraint

### DIFF
--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -323,7 +323,7 @@ namespace type_safe
     /// \effects Changes `val` so that it is in the interval.
     /// If it is not in the interval, assigns the bound that is closer to the value.
     template <typename T, typename LowerConstant, typename UpperConstant, typename U>
-    void clamp(const constraints::closed_interval<T,LowerConstant,UpperConstant>& interval, U& val)
+    void clamp(const constraints::closed_interval<T, LowerConstant, UpperConstant>& interval, U& val)
     {
         if (val < interval.get_lower_bound())
             val = static_cast<U>(interval.get_lower_bound());
@@ -332,14 +332,14 @@ namespace type_safe
     }
 
     /// A `Verifier` for [type_safe::constrained_type<T, Constraint, Verifier]() that clamps the value to make it valid.
-    /// It must be used together with [type_safe::constraints::less_equal<T, BoundConstant>](), [type_safe::constraints::greater_equal<T, BoundConstant>]() or [type_safe::constraints::closed_interval<T>]().
+    /// It must be used together with [type_safe::constraints::less_equal<T, BoundConstant>](), [type_safe::constraints::greater_equal<T, BoundConstant>]() or [type_safe::constraints::closed_interval<T, LowerConstant, UpperConstant>]().
     struct clamping_verifier
     {
         /// \effects If `val` is greater than the bound of `p`,
         /// assigns the bound to `val`.
         /// Otherwise does nothing.
         template <typename Value, typename T, typename BoundConstant>
-        static void verify(Value& val, const constraints::less_equal<T,BoundConstant>& p)
+        static void verify(Value& val, const constraints::less_equal<T, BoundConstant>& p)
         {
             if (!p(val))
                 val = static_cast<Value>(p.get_bound());

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -147,7 +147,8 @@ namespace type_safe
 
             template <typename U, bool req = upper_is_dynamic, typename LC = LowerConstant,
                       typename = typename std::enable_if<req &&
-                                    decay_same<typename LC::value_type>::value>::type>
+                                    decay_same<typename LC::value_type>::value>::type,
+                      typename = typename std::enable_if<decay_same<U>::value>::type>
             bounded(U&& upper)
             : Upper(std::forward<U>(upper))
             {
@@ -155,7 +156,8 @@ namespace type_safe
 
             template <typename U, typename UC = UpperConstant, bool req = lower_is_dynamic,
                       typename = typename std::enable_if<req &&
-                                    decay_same<typename UC::value_type>::value>::type>
+                                    decay_same<typename UC::value_type>::value>::type,
+                      typename = typename std::enable_if<decay_same<U>::value>::type>
             bounded(U&& lower)
             : Lower(std::forward<U>(lower))
             {
@@ -163,7 +165,8 @@ namespace type_safe
 
             /// \exclude
             template <typename U, bool req = lower_is_dynamic!=upper_is_dynamic,
-                      typename = typename std::enable_if<!req>::type>
+                      typename = typename std::enable_if<!req>::type,
+                      typename = typename std::enable_if<decay_same<U>::value>::type>
             bounded(U&&)
             {
                 static_assert(req,"one-argument constructors require a dynamic and static bound");

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -23,6 +23,7 @@ namespace type_safe
             template <typename T>
             struct Wrapper
             {
+                using value_type = T;
                 T value;
             };
 
@@ -201,36 +202,79 @@ namespace type_safe
 
         /// A `Constraint` for the [type_safe::constrained_type<T, Constraint, Verifier>]().
         /// A value is valid if it is between two given bounds but not the bounds themselves.
-        template <typename T>
-        using open_interval = bounded<T, open, open>;
+        template <typename T, typename LowerConstant = dynamic_bound,
+                              typename UpperConstant = dynamic_bound>
+        using open_interval = bounded<T, open, open, LowerConstant, UpperConstant>;
 
         /// A `Constraint` for the [type_safe::constrained_type<T, Constraint, Verifier>]().
         /// A value is valid if it is between two given bounds or the bounds themselves.
-        template <typename T>
-        using closed_interval = bounded<T, closed, closed>;
+        template <typename T, typename LowerConstant = dynamic_bound,
+                              typename UpperConstant = dynamic_bound>
+        using closed_interval = bounded<T, closed, closed, LowerConstant, UpperConstant>;
     } // namespace constraints
 
     /// \exclude
     namespace detail
     {
         template <typename T, typename U1, typename U2>
-        struct bounded_value_type_impl
+        struct assert_value_type
         {
-            static_assert(!std::is_same<T, U1>::value && !std::is_same<U1, U2>::value,
-                          "make_bounded() called with mismatching types");
+            static_assert(std::is_same<T, U1>::value && std::is_same<U1, U2>::value,
+                          "types of bounds in call mismatch");
         };
 
-        template <typename T>
-        struct bounded_value_type_impl<T, T, T>
+        using constraints::detail::is_dynamic;
+
+        template <typename T, typename, typename, typename...>
+        struct bounded_value_type_impl
         {
+            static_assert(!std::is_same<T,T>::value,"call has too many runtime bounds");
+        };
+
+        template <typename T, typename LowerConstant, typename UpperConstant,
+                  typename U1, typename U2>
+        struct bounded_value_type_impl<T, LowerConstant, UpperConstant, U1, U2>
+        : assert_value_type<T, U1, U2>
+        {
+            static constexpr bool lower_is_dynamic = is_dynamic<LowerConstant>::value;
+            static constexpr bool upper_is_dynamic = is_dynamic<UpperConstant>::value;
+
+            static_assert(lower_is_dynamic && upper_is_dynamic,"call has too many runtime bounds");
             using type = T;
         };
 
-        template <typename T, typename U1, typename U2>
+        template <typename T, typename BoundConstant>
+        using value_type = typename constraints::detail::Base<T, BoundConstant>::value_type;
+
+        template <typename T, typename LowerConstant, typename UpperConstant, typename U>
+        struct bounded_value_type_impl<T, LowerConstant, UpperConstant, U>
+        : assert_value_type<T, value_type<U, LowerConstant>, value_type<U, UpperConstant>>
+        {
+            static constexpr bool lower_is_dynamic = is_dynamic<LowerConstant>::value;
+            static constexpr bool upper_is_dynamic = is_dynamic<UpperConstant>::value;
+
+            static_assert(lower_is_dynamic!=upper_is_dynamic,"+/- 1 too many runtime bounds");
+            using type = T;
+        };
+
+        template <typename T, typename LowerConstant, typename UpperConstant>
+        struct bounded_value_type_impl<T, LowerConstant, UpperConstant>
+        : assert_value_type<T, typename LowerConstant::value_type,
+                               typename UpperConstant::value_type>
+        {
+            static constexpr bool lower_is_dynamic = is_dynamic<LowerConstant>::value;
+            static constexpr bool upper_is_dynamic = is_dynamic<UpperConstant>::value;
+
+            static_assert(!lower_is_dynamic && !upper_is_dynamic,"call needs runtime bounds");
+            using type = T;
+        };
+
+        template <typename T, typename LowerConstant, typename UpperConstant, typename... Us>
         using bounded_value_type =
             typename bounded_value_type_impl<typename std::decay<T>::type,
-                                             typename std::decay<U1>::type,
-                                             typename std::decay<U2>::type>::type;
+                                             LowerConstant,
+                                             UpperConstant,
+                                             typename std::decay<Us>::type...>::type;
     } // namespace detail
 
     /// An alias for [type_safe::constrained_type<T, Constraint, Verifier>]() that uses [type_safe::constraints::bounded<T, LowerInclusive, UpperInclusive, LowerConstant, UpperConstant>]() as its `Constraint`.
@@ -242,37 +286,44 @@ namespace type_safe
         constrained_type<T, constraints::bounded<T, LowerInclusive, UpperInclusive,
                                                     LowerConstant, UpperConstant>>;
 
-    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive LowerConstant, UpperConstant>]() with the given `value` and lower and upper bounds,
-    /// where those bounds are valid values as well.
-    template <typename T, typename U1, typename U2>
-    auto make_bounded(T&& value, U1&& lower, U2&& upper)
-        -> bounded_type<detail::bounded_value_type<T, U1, U2>, true, true>
+    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive LowerConstant, UpperConstant>]() with the given `value` and lower and upper dynamic bounds, in that order,
+    /// where the bounds are valid values as well.
+    /// \remarks `sizeof...(Us)` shall be equal to the number of dynamic bounds.
+    template <typename LowerConstant = constraints::dynamic_bound,
+              typename UpperConstant = constraints::dynamic_bound,
+              typename T, typename... Us>
+    auto make_bounded(T&& value, Us&&... bounds)
+        -> bounded_type<detail::bounded_value_type<T, LowerConstant, UpperConstant, Us...>,
+                        true, true, LowerConstant, UpperConstant>
     {
-        using value_type = detail::bounded_value_type<T, U1, U2>;
-        return bounded_type<value_type, true,
-                            true>(std::forward<T>(value),
-                                  constraints::closed_interval<value_type>(std::forward<U1>(lower),
-                                                                           std::forward<U2>(
-                                                                               upper)));
+        using value_type = detail::bounded_value_type<T, LowerConstant, UpperConstant, Us...>;
+        return bounded_type<value_type, true, true, LowerConstant, UpperConstant>(
+                    std::forward<T>(value),
+                    constraints::closed_interval<value_type, LowerConstant, UpperConstant>(
+                        std::forward<Us>(bounds)...));
     }
 
-    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive LowerConstant, UpperConstant>]() with the given `value` and lower and upper bounds,
-    /// where those bounds are not valid values.
-    template <typename T, typename U1, typename U2>
-    auto make_bounded_exclusive(T&& value, U1&& lower, U2&& upper)
-        -> bounded_type<detail::bounded_value_type<T, U1, U2>, false, false>
+    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive LowerConstant, UpperConstant>]() with the given `value` and lower and upper dynamic bounds, in that order,
+    /// where the bounds are not valid values.
+    /// \remarks `sizeof...(Us)` shall be equal to the number of dynamic bounds.
+    template <typename LowerConstant = constraints::dynamic_bound,
+              typename UpperConstant = constraints::dynamic_bound,
+              typename T, typename... Us>
+    auto make_bounded_exclusive(T&& value, Us&&... bounds)
+        -> bounded_type<detail::bounded_value_type<T, LowerConstant, UpperConstant, Us...>,
+                        false, false, LowerConstant, UpperConstant>
     {
-        using value_type = detail::bounded_value_type<T, U1, U2>;
-        return bounded_type<value_type, false,
-                            false>(std::forward<T>(value),
-                                   constraints::open_interval<value_type>(std::forward<U1>(lower),
-                                                                          std::forward<U2>(upper)));
+        using value_type = detail::bounded_value_type<T, LowerConstant, UpperConstant, Us...>;
+        return bounded_type<value_type, false, false, LowerConstant, UpperConstant>(
+                    std::forward<T>(value),
+                    constraints::open_interval<value_type, LowerConstant, UpperConstant>(
+                        std::forward<Us>(bounds)...));
     }
 
     /// \effects Changes `val` so that it is in the interval.
     /// If it is not in the interval, assigns the bound that is closer to the value.
-    template <typename T, typename U>
-    void clamp(const constraints::closed_interval<T>& interval, U& val)
+    template <typename T, typename LowerConstant, typename UpperConstant, typename U>
+    void clamp(const constraints::closed_interval<T,LowerConstant,UpperConstant>& interval, U& val)
     {
         if (val < interval.get_lower_bound())
             val = static_cast<U>(interval.get_lower_bound());
@@ -287,8 +338,8 @@ namespace type_safe
         /// \effects If `val` is greater than the bound of `p`,
         /// assigns the bound to `val`.
         /// Otherwise does nothing.
-        template <typename Value, typename T>
-        static void verify(Value& val, const constraints::less_equal<T>& p)
+        template <typename Value, typename T, typename BoundConstant>
+        static void verify(Value& val, const constraints::less_equal<T,BoundConstant>& p)
         {
             if (!p(val))
                 val = static_cast<Value>(p.get_bound());
@@ -297,38 +348,47 @@ namespace type_safe
         /// \effects If `val` is less than the bound of `p`,
         /// assigns the bound to `val`.
         /// Otherwise does nothing.
-        template <typename Value, typename T>
-        static void verify(Value& val, const constraints::greater_equal<T>& p)
+        template <typename Value, typename T, typename BoundConstant>
+        static void verify(Value& val, const constraints::greater_equal<T, BoundConstant>& p)
         {
             if (!p(val))
                 val = static_cast<Value>(p.get_bound());
         }
 
         /// \effects Same as `clamp(interval, val)`.
-        template <typename Value, typename T>
-        static void verify(Value& val, const constraints::closed_interval<T>& interval)
+        template <typename Value, typename T, typename LowerConstant, typename UpperConstant>
+        static void verify(
+            Value& val,
+            const constraints::closed_interval<T, LowerConstant, UpperConstant>& interval)
         {
             clamp(interval, val);
         }
     };
 
-    /// An alias for [type_safe::constrained_type<T, Constraint, Verifier>]() that uses [type_safe::constraints::closed_interval<T>]() as its `Constraint`
+    /// An alias for [type_safe::constrained_type<T, Constraint, Verifier>]() that uses [type_safe::constraints::closed_interval<T, LowerConstant, UpperConstant>]() as its `Constraint`
     /// and [type_safe::clamping_verifier]() as its `Verifier`.
     /// \notes This is some type where the values are always clamped so that they are in a certain interval.
-    template <typename T>
-    using clamped_type = constrained_type<T, constraints::closed_interval<T>, clamping_verifier>;
+    template <typename T, typename LowerConstant = constraints::dynamic_bound,
+                          typename UpperConstant = constraints::dynamic_bound>
+    using clamped_type = constrained_type<T,
+                                          constraints::closed_interval<T, LowerConstant,
+                                                                          UpperConstant>,
+                                          clamping_verifier>;
 
-    /// \returns A [type_safe::clamped_type<T>]() with the given `value` and lower and upper bounds.
-    template <typename T, typename U1, typename U2>
-    auto make_clamped(T&& value, U1&& lower, U2&& upper)
-        -> clamped_type<detail::bounded_value_type<T, U1, U2>>
+    /// \returns A [type_safe::clamped_type<T, LowerConstant, UpperConstant>]() with the given `value` and lower and upper dynamic bounds, in that order.
+    /// \remarks `sizeof...(Us)` shall be equal to the number of dynamic bounds.
+    template <typename LowerConstant = constraints::dynamic_bound,
+              typename UpperConstant = constraints::dynamic_bound,
+              typename T, typename... Us>
+    auto make_clamped(T&& value, Us&&... bounds)
+        -> clamped_type<detail::bounded_value_type<T, LowerConstant, UpperConstant, Us...>,
+                        LowerConstant, UpperConstant>
     {
-        using value_type = detail::bounded_value_type<T, U1, U2>;
-        return clamped_type<value_type>(std::forward<T>(value),
-                                        constraints::closed_interval<value_type>(std::forward<U1>(
-                                                                                     lower),
-                                                                                 std::forward<U2>(
-                                                                                     upper)));
+        using value_type = detail::bounded_value_type<T, LowerConstant, UpperConstant, Us...>;
+        return clamped_type<value_type, LowerConstant, UpperConstant>(
+                    std::forward<T>(value),
+                    constraints::closed_interval<value_type, LowerConstant, UpperConstant>(
+                        std::forward<Us>(bounds)...));
     }
 } // namespace type_safe
 

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -20,18 +20,18 @@ namespace type_safe
         {
             // Base to enable empty base optimization when BoundConstant is not dynamic_bound.
             // Neccessary when T is not a class.
-            template <class T>
+            template <typename T>
             struct Wrapper
             {
                 T value;
             };
 
-            template <class BoundConstant>
+            template <typename BoundConstant>
             struct is_dynamic : std::is_same<BoundConstant,dynamic_bound>
             {
             };
 
-            template <class T, class BoundConstant>
+            template <typename T, typename BoundConstant>
             using Base = typename std::conditional<is_dynamic<BoundConstant>::value,
                                                    Wrapper<T>,
                                                    BoundConstant>::type;

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -151,8 +151,6 @@ namespace type_safe
             bounded(U&& upper)
             : Upper(std::forward<U>(upper))
             {
-                static_assert(!lower_is_dynamic && upper_is_dynamic,
-                              "constructor requires dynamic upper bound");
             }
 
             template <typename U, typename UC = UpperConstant, bool req = lower_is_dynamic,
@@ -161,8 +159,14 @@ namespace type_safe
             bounded(U&& lower)
             : Lower(std::forward<U>(lower))
             {
-                static_assert(lower_is_dynamic && !upper_is_dynamic,
-                              "constructor requires dynamic lower bound");
+            }
+
+            /// \exclude
+            template <typename U, bool req = lower_is_dynamic!=upper_is_dynamic,
+                      typename = typename std::enable_if<!req>::type>
+            bounded(U&&)
+            {
+                static_assert(req,"one-argument constructors require a dynamic and static bound");
             }
 
             template <typename U1, typename U2,

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -113,8 +113,8 @@ namespace type_safe
         /// A value is valid if it is between two given bounds,
         /// `LowerInclusive`/`UpperInclusive` control whether the lower/upper bound itself is valid too.
         /// `LowerConstant`/`UpperConstant` control whether the lower/upper bound is specified statically or dinamically.
-        /// When they are `dynamic_bound`, the bounds are specified at run-time. Otherwise, they must match
-        /// the `boost::hana::Constant` concept, in which case their value is the bound.
+        /// When one is `dynamic_bound`, its bound is specified at run-time. Otherwise, it must match
+        /// the interface and semantics of `std::integral_constant<T>`, in which case its `value` is the bound.
         template <typename T, bool LowerInclusive, bool UpperInclusive,
                   typename LowerConstant = dynamic_bound,
                   typename UpperConstant = dynamic_bound>

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -112,8 +112,8 @@ namespace type_safe
         /// A `Constraint` for the [type_safe::constrained_type<T, Constraint, Verifier>]().
         /// A value is valid if it is between two given bounds,
         /// `LowerInclusive`/`UpperInclusive` control whether the lower/upper bound itself is valid too.
-        /// `LowerConstant`/`UpperConstant` control whether the lower/upper bound is specified statically or dinamically.
-        /// When one is `dynamic_bound`, its bound is specified at run-time. Otherwise, it must match
+        /// `LowerConstant`/`UpperConstant` control whether the lower/upper bound is specified statically or dynamically.
+        /// When one is `dynamic_bound`, its bound is specified at runtime. Otherwise, it must match
         /// the interface and semantics of `std::integral_constant<T>`, in which case its `value` is the bound.
         template <typename T, bool LowerInclusive, bool UpperInclusive,
                   typename LowerConstant = dynamic_bound,

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -114,7 +114,7 @@ namespace type_safe
         /// `LowerInclusive`/`UpperInclusive` control whether the lower/upper bound itself is valid too.
         /// `LowerConstant`/`UpperConstant` control whether the lower/upper bound is specified statically or dinamically.
         /// When they are `dynamic_bound`, the bounds are specified at run-time. Otherwise, they must match
-        /// the `boost::hana::Constant` concept, in which case their nested `value` is the bound.
+        /// the `boost::hana::Constant` concept, in which case their value is the bound.
         template <typename T, bool LowerInclusive, bool UpperInclusive,
                   typename LowerConstant = dynamic_bound,
                   typename UpperConstant = dynamic_bound>

--- a/include/type_safe/bounded_type.hpp
+++ b/include/type_safe/bounded_type.hpp
@@ -230,7 +230,7 @@ namespace type_safe
                                              typename std::decay<U2>::type>::type;
     } // namespace detail
 
-    /// An alias for [type_safe::constrained_type<T, Constraint, Verifier>]() that uses [type_safe::constraints::bounded<T, LowerInclusive, UpperInclusive>]() as its `Constraint`.
+    /// An alias for [type_safe::constrained_type<T, Constraint, Verifier>]() that uses [type_safe::constraints::bounded<T, LowerInclusive, UpperInclusive, LowerConstant, UpperConstant>]() as its `Constraint`.
     /// \notes This is some type where the values must be in a certain interval.
     template <typename T, bool LowerInclusive, bool UpperInclusive,
               typename LowerConstant = constraints::dynamic_bound,
@@ -239,7 +239,7 @@ namespace type_safe
         constrained_type<T, constraints::bounded<T, LowerInclusive, UpperInclusive,
                                                     LowerConstant, UpperConstant>>;
 
-    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive>]() with the given `value` and lower and upper bounds,
+    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive LowerConstant, UpperConstant>]() with the given `value` and lower and upper bounds,
     /// where those bounds are valid values as well.
     template <typename T, typename U1, typename U2>
     auto make_bounded(T&& value, U1&& lower, U2&& upper)
@@ -253,7 +253,7 @@ namespace type_safe
                                                                                upper)));
     }
 
-    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive>]() with the given `value` and lower and upper bounds,
+    /// \returns A [type_safe::bounded_type<T, LowerInclusive, UpperInclusive LowerConstant, UpperConstant>]() with the given `value` and lower and upper bounds,
     /// where those bounds are not valid values.
     template <typename T, typename U1, typename U2>
     auto make_bounded_exclusive(T&& value, U1&& lower, U2&& upper)
@@ -278,7 +278,7 @@ namespace type_safe
     }
 
     /// A `Verifier` for [type_safe::constrained_type<T, Constraint, Verifier]() that clamps the value to make it valid.
-    /// It must be used together with [type_safe::constraints::less_equal<T>](), [type_safe::constraints::greater_equal<T>]() or [type_safe::constraints::closed_interval<T>]().
+    /// It must be used together with [type_safe::constraints::less_equal<T, BoundConstant>](), [type_safe::constraints::greater_equal<T, BoundConstant>]() or [type_safe::constraints::closed_interval<T>]().
     struct clamping_verifier
     {
         /// \effects If `val` is greater than the bound of `p`,


### PR DESCRIPTION
Implements #13.

I've made the PR to allow discussing the code here, and the idea in #13.

What would be left to be done (if the idea, and this implementation is to be pursued):

- [x] Either
  - ~~Use `boost::hana` to retrieve the `Constant`s value. This requires C++14.~~
  - Change the requirement on the `Constant`s to something like `std::integral_constant`-like.
- [x] Allow mixing static and dynamic bounds.
- [x] Add support to the other declarations.
- [x] Update entities in documentation with the new template arguments.
