### PR TITLE
Improvement of the dereference operator

### DIFF
--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -362,26 +362,43 @@ namespace type_safe
         {
             Result& operator*()
             {
-                using type = underlying_type<StrongTypedef>;
-                return *static_cast<type&>(static_cast<StrongTypedef&>(*this));
+                return *deref_impl(get(static_cast<StrongTypedef&>(*this)));
             }
 
             const Result& operator*() const
             {
-                using type = underlying_type<StrongTypedef>;
-                return *static_cast<const type&>(static_cast<const StrongTypedef&>(*this));
+                return *deref_impl(get(static_cast<StrongTypedef const&>(*this)));
             }
 
             ResultPtr operator->()
             {
-                using type = underlying_type<StrongTypedef>;
-                return static_cast<type&>(static_cast<StrongTypedef&>(*this));
+                return deref_impl(get(static_cast<StrongTypedef&>(*this)));
             }
 
             ResultConstPtr operator->() const
             {
-                using type = underlying_type<StrongTypedef>;
-                return static_cast<const type&>(static_cast<const StrongTypedef&>(*this));
+                return deref_impl(get(static_cast<StrongTypedef const&>(*this)));
+            }
+
+        private:
+            ResultPtr deref_impl(ResultPtr r)
+            {
+                return r;
+            }
+
+            ResultConstPtr deref_impl(ResultConstPtr r)
+            {
+                return r;
+            }
+
+            ResultPtr deref_impl(Result& r)
+            {
+                return &r;
+            }
+
+            ResultConstPtr deref_impl(Result const& r)
+            {
+                return &r;
             }
         };
 

--- a/test/strong_typedef.cpp
+++ b/test/strong_typedef.cpp
@@ -205,7 +205,7 @@ TEST_CASE("strong_typedef")
         REQUIRE(static_cast<int>(+a) == 2);
         REQUIRE(static_cast<int>(-a) == -2);
     }
-    SECTION("dereference")
+    SECTION("dereference pointer")
     {
         struct test
         {
@@ -220,6 +220,23 @@ TEST_CASE("strong_typedef")
         type a(&t);
         REQUIRE((*a).a == 0);
         REQUIRE(a->a == 0);
+    }
+    SECTION("dereference value to forward methods")
+    {
+        struct test
+        {
+            test() {}
+            int run() { return 0; }
+        } t;
+
+        struct type : strong_typedef<type, test>, strong_typedef_op::dereference<type, test>
+        {
+            using strong_typedef::strong_typedef;
+        };
+
+        type a(t);
+        REQUIRE(a->run() == 0);
+        REQUIRE((*a).run() == 0);
     }
     SECTION("array subscript")
     {


### PR DESCRIPTION
Hi,

I was reading your awesome blog (https://foonathan.github.io/blog/2016/10/19/strong-typedefs.html) and then had a look at the strong_typedef on your GitHub. I had the need for this from almost a year now, and this helps a lot.

I also understood that you looked for a way to call arbitrary method from the underlying object of the strong_typedef. I saw the opportunity to provide the feature you desired by playing a bit with the dereference module you already provide. And I was considering tweaking your implementation like this for my need as well.

The rationale is that if a user makes use of the dereference on a strong_typedef wrapping a pointer, the semantic should not change. But then you can provide it when the user wraps a value type, and by the overloading of the "deref_impl" you can forward functions on the value as well.

I would be glad knowing what you think about it. My feeling is that it maybe a bad idea to mix it with the dereference operator.

Thank you,
Quentin