### PR TITLE
Install the library with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ install( FILES
 # other subdirectories
 # only add if not inside add_subdirectory()
 option(TYPE_SAFE_BUILD_TEST_EXAMPLE "build test and example" OFF)
+option(BUILD_TESTING "build test and example" OFF) # The ctest variable for building tests
 if(${TYPE_SAFE_BUILD_TEST_EXAMPLE} OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR) OR ${BUILD_TESTING})
     enable_testing()
     add_subdirectory(example/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(TYPE_SAFE)
 
-include(external/external.cmake)
+find_package(debug_assert)
+if(NOT debug_assert_FOUND)
+    include(external/external.cmake)
+endif()
 
 # options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -78,8 +81,9 @@ set(header_files
     ${CMAKE_CURRENT_SOURCE_DIR}/include/type_safe/visitor.hpp)
 
 add_library(type_safe INTERFACE)
-target_sources(type_safe INTERFACE ${detail_header_files} ${header_files})
-target_include_directories(type_safe INTERFACE include/)
+target_sources(type_safe INTERFACE $<BUILD_INTERFACE:${detail_header_files} ${header_files}>)
+target_include_directories(type_safe INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+target_include_directories(type_safe SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
 target_compile_definitions(type_safe INTERFACE
                                      TYPE_SAFE_ENABLE_ASSERTIONS=${_type_safe_enable_assertions}
                                      TYPE_SAFE_ENABLE_PRECONDITION_CHECKS=${_type_safe_enable_precondition_checks}
@@ -91,10 +95,39 @@ if(MSVC)
    target_compile_options(type_safe INTERFACE /wd4800) # truncation to bool warning
 endif()
 
+# Setup package config
+include( CMakePackageConfigHelpers )
+set(CONFIG_PACKAGE_INSTALL_DIR lib/cmake/type_safe)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/type_safe-config-version.cmake
+  VERSION 0.1
+  COMPATIBILITY SameMajorVersion
+)
+
+# Install target
+install(TARGETS type_safe 
+    EXPORT type_safe-targets
+    DESTINATION lib)
+
+install(DIRECTORY include/type_safe DESTINATION include)
+
+install( EXPORT type_safe-targets
+  DESTINATION
+    ${CONFIG_PACKAGE_INSTALL_DIR}
+)
+
+install( FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/type_safe-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/type_safe-config-version.cmake
+  DESTINATION
+    ${CONFIG_PACKAGE_INSTALL_DIR} )
+
 # other subdirectories
 # only add if not inside add_subdirectory()
 option(TYPE_SAFE_BUILD_TEST_EXAMPLE "build test and example" OFF)
-if(${TYPE_SAFE_BUILD_TEST_EXAMPLE} OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR))
+if(${TYPE_SAFE_BUILD_TEST_EXAMPLE} OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR) OR ${BUILD_TESTING})
+    enable_testing()
     add_subdirectory(example/)
     add_subdirectory(test/)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,22 +106,26 @@ write_basic_package_version_file(
 )
 
 # Install target
-install(TARGETS type_safe 
-    EXPORT type_safe-targets
-    DESTINATION lib)
-
 install(DIRECTORY include/type_safe DESTINATION include)
 
-install( EXPORT type_safe-targets
-  DESTINATION
-    ${CONFIG_PACKAGE_INSTALL_DIR}
-)
+# Only export target when using imported targets
+if(debug_assert_FOUND)
+    install(TARGETS type_safe 
+        EXPORT type_safe-targets
+        DESTINATION lib)
 
-install( FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/type_safe-config.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/type_safe-config-version.cmake
-  DESTINATION
-    ${CONFIG_PACKAGE_INSTALL_DIR} )
+    install( EXPORT type_safe-targets
+      DESTINATION
+        ${CONFIG_PACKAGE_INSTALL_DIR}
+    )
+
+    install( FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/type_safe-config.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/type_safe-config-version.cmake
+      DESTINATION
+        ${CONFIG_PACKAGE_INSTALL_DIR} )
+
+endif()
 
 # other subdirectories
 # only add if not inside add_subdirectory()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ write_basic_package_version_file(
 install(DIRECTORY include/type_safe DESTINATION include)
 
 # Only export target when using imported targets
-if(debug_assert_FOUND)
+if(TYPE_SAFE_HAS_IMPORTED_TARGETS)
     install(TARGETS type_safe 
         EXPORT type_safe-targets
         DESTINATION lib)

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -2,6 +2,12 @@
 # This file is subject to the license terms in the LICENSE file
 # found in the top-level directory of this distribution.
 
-execute_process(COMMAND git submodule update --init -- external/debug_assert
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/debug_assert)
+find_package(debug_assert)
+if(debug_assert_FOUND)
+    set(TYPE_SAFE_HAS_IMPORTED_TARGETS On)
+else()
+    set(TYPE_SAFE_HAS_IMPORTED_TARGETS Off)
+    execute_process(COMMAND git submodule update --init -- external/debug_assert
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/debug_assert)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,5 +52,4 @@ elseif(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
     target_compile_definitions(type_safe_test PRIVATE TYPE_SAFE_TEST_NO_STATIC_ASSERT)
 endif()
 
-enable_testing()
 add_test(NAME test COMMAND type_safe_test)

--- a/type_safe-config.cmake
+++ b/type_safe-config.cmake
@@ -1,0 +1,46 @@
+
+include(CMakeFindDependencyMacro OPTIONAL RESULT_VARIABLE _CMakeFindDependencyMacro_FOUND)
+if (NOT _CMakeFindDependencyMacro_FOUND)
+  macro(find_dependency dep)
+    if (NOT ${dep}_FOUND)
+      set(cmake_fd_version)
+      if (${ARGC} GREATER 1)
+        set(cmake_fd_version ${ARGV1})
+      endif()
+      set(cmake_fd_exact_arg)
+      if(${CMAKE_FIND_PACKAGE_NAME}_FIND_VERSION_EXACT)
+        set(cmake_fd_exact_arg EXACT)
+      endif()
+      set(cmake_fd_quiet_arg)
+      if(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+        set(cmake_fd_quiet_arg QUIET)
+      endif()
+      set(cmake_fd_required_arg)
+      if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
+        set(cmake_fd_required_arg REQUIRED)
+      endif()
+      find_package(${dep} ${cmake_fd_version}
+          ${cmake_fd_exact_arg}
+          ${cmake_fd_quiet_arg}
+          ${cmake_fd_required_arg}
+      )
+      string(TOUPPER ${dep} cmake_dep_upper)
+      if (NOT ${dep}_FOUND AND NOT ${cmake_dep_upper}_FOUND)
+        set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${CMAKE_FIND_PACKAGE_NAME} could not be found because dependency ${dep} could not be found.")
+        set(${CMAKE_FIND_PACKAGE_NAME}_FOUND False)
+        return()
+      endif()
+      set(cmake_fd_version)
+      set(cmake_fd_required_arg)
+      set(cmake_fd_quiet_arg)
+      set(cmake_fd_exact_arg)
+    endif()
+  endmacro()
+endif()
+
+find_dependency(debug_assert)
+
+include( "${CMAKE_CURRENT_LIST_DIR}/type_safe-targets.cmake" )
+
+set( type_safe_LIBRARY type_safe)
+set( type_safe_LIBRARIES type_safe)


### PR DESCRIPTION
This relies on this pull request [here](https://github.com/foonathan/debug_assert/pull/6). It will find the installed `debug_assert` library if available otherwise it will fall back onto your git module logic. In addition, this will install the target with a corresponding cmake package config, so the user can just use `type_safe` target in other projects with `find_package(type_safe)`.