### PR TITLE
std::hash specializations for boolean, integer and floating_point type wrappers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/debug_assert"]
 	path = external/debug_assert
-	url = https://github.com/foonathan/debug_assert
+url=https://github.com/foonathan/debug_assert/tree/4de9db29ad70faf37bd127edecafa2a12d87999e

--- a/include/type_safe/boolean.hpp
+++ b/include/type_safe/boolean.hpp
@@ -13,8 +13,21 @@
 
 namespace type_safe
 {
-    class boolean;
+	class boolean;
+} // namespace type_safe
 
+namespace std
+{
+	template<>
+	struct hash<type_safe::boolean>
+	{
+	public:
+		size_t operator()(const type_safe::boolean& boolean) const;
+	};
+} // namespace std
+
+namespace type_safe
+{
     /// \exclude
     namespace detail
     {
@@ -79,8 +92,10 @@ namespace type_safe
         {
             return boolean(!value_);
         }
-
     private:
+		template<typename T>
+		friend struct std::hash;
+
         bool value_;
     };
 
@@ -209,5 +224,12 @@ namespace type_safe
 
 #undef TYPE_SAFE_DETAIL_MAKE_PREDICATE
 } // namespace type_safe
+
+namespace std{
+	size_t hash<type_safe::boolean>::operator()(const type_safe::boolean& boolean) const
+	{
+		return hash<bool>()(boolean.value_);
+	}
+} // namespace std
 
 #endif // TYPE_SAFE_BOOLEAN_HPP_INCLUDED

--- a/include/type_safe/floating_point.hpp
+++ b/include/type_safe/floating_point.hpp
@@ -14,7 +14,20 @@ namespace type_safe
 {
     template <typename FloatT>
     class floating_point;
+} // namespace type_safe
 
+namespace std
+{
+	template<typename T>
+	struct hash<type_safe::floating_point<T>>
+	{
+	public:
+		size_t operator()(type_safe::floating_point<T>& floating_point) const;
+	};
+} // namespace std
+
+namespace type_safe
+{
     /// \exclude
     namespace detail
     {
@@ -252,6 +265,9 @@ namespace type_safe
 #undef TYPE_SAFE_DETAIL_MAKE_OP
 
     private:
+		template<typename T>
+		friend struct std::hash;
+
         floating_point_type value_;
     };
 
@@ -443,5 +459,13 @@ namespace type_safe
         return out << static_cast<FloatT>(f);
     }
 } // namespace type_safe
+
+namespace std{
+	template<typename T>
+	size_t hash<type_safe::floating_point<T>>::operator()(type_safe::floating_point<T>& floating_point) const
+	{
+		return hash<T>()(floating_point.value_);
+	}
+} // namespace std
 
 #endif // TYPE_SAFE_FLOATING_POINT_HPP_INCLUDED

--- a/include/type_safe/integer.hpp
+++ b/include/type_safe/integer.hpp
@@ -17,7 +17,20 @@ namespace type_safe
 {
     template <typename IntegerT, class Policy = arithmetic_policy_default>
     class integer;
+} // namespace type_safe
 
+namespace std
+{
+	template<typename T>
+	struct hash<type_safe::integer<T>>
+	{
+	public:
+		size_t operator()(const type_safe::integer<T>& integer) const;
+	};
+} // namespace std
+
+namespace type_safe
+{
     /// \exclude
     namespace detail
     {
@@ -305,6 +318,9 @@ namespace type_safe
 #undef TYPE_SAFE_DETAIL_MAKE_OP
 
     private:
+		template<typename T>
+		friend struct std::hash;
+
         integer_type value_;
     };
 
@@ -685,5 +701,13 @@ namespace type_safe
         return out << static_cast<IntegerT>(i);
     }
 } // namespace type_safe
+
+namespace std{
+	template<typename T>
+	size_t hash<type_safe::integer<T>>::operator()(const type_safe::integer<T>& integer) const
+	{
+		return hash<T>()(integer.value_);
+	}
+} // namespace std
 
 #endif // TYPE_SAFE_INTEGER_HPP_INCLUDED


### PR DESCRIPTION
This is a partial-solution to https://github.com/foonathan/type_safe/issues/52
I wanted to create a sample for review before I finish building hash specializations for the remaining type wrappers; please share any feedback you have for these implementations.
