### PR TITLE
Compile error in reference.hpp when TYPE_SAFE_ENABLE_WRAPPER is disabled

### DIFF
--- a/include/type_safe/reference.hpp
+++ b/include/type_safe/reference.hpp
@@ -372,7 +372,7 @@ namespace type_safe
         /// \returns An iterator one past the last element of the array.
         iterator end() const noexcept
         {
-            return begin_ + size_.get();
+            return begin_ + get(size_);
         }
 
         /// \returns A pointer to the beginning of the array.

--- a/include/type_safe/reference.hpp
+++ b/include/type_safe/reference.hpp
@@ -372,7 +372,7 @@ namespace type_safe
         /// \returns An iterator one past the last element of the array.
         iterator end() const noexcept
         {
-            return begin_ + static_cast<::size_t>(size_);
+            return begin_ + static_cast<std::size_t>(size_);
         }
 
         /// \returns A pointer to the beginning of the array.

--- a/include/type_safe/reference.hpp
+++ b/include/type_safe/reference.hpp
@@ -372,7 +372,7 @@ namespace type_safe
         /// \returns An iterator one past the last element of the array.
         iterator end() const noexcept
         {
-            return begin_ + get(size_);
+            return begin_ + static_cast<::size_t>(size_);
         }
 
         /// \returns A pointer to the beginning of the array.


### PR DESCRIPTION
Consider this code:
```
#include <type_safe/reference.hpp>

int main()
{
  return 0;
}
```

On Apple Clang 8.1 (at least) it fails to compile when TYPE_SAFE_ENABLE_WRAPPER is disabled because of this error:
```
$ clang++ -std=c++14 -DTYPE_SAFE_ENABLE_WRAPPER=0 issue.cpp
In file included from issue.cpp:1:
type_safe/include/type_safe/reference.hpp:375:34: error: member reference base type
      'const size_t' (aka 'const unsigned long') is not a structure or union
            return begin_ + size_.get();
                            ~~~~~^~~~
1 error generated.
```

Calling `get(size_)` instead of `size_.get()` fixes the problem.