### PR TITLE
Enable visitors that return non-decayed types.

### DIFF
--- a/include/type_safe/visitor.hpp
+++ b/include/type_safe/visitor.hpp
@@ -19,19 +19,20 @@ namespace type_safe
         template <typename A, typename B>
         struct common_type
         {
-            using type = typename std::common_type<A, B>::type;
+            using type = typename std::conditional<std::is_same<A, B>::value, A,
+                                                   typename std::common_type<A, B>::type>::type;
         };
 
         template <typename A>
         struct common_type<A, void>
         {
-            using type = typename std::common_type<A>::type;
+            using type = A;
         };
 
         template <typename A>
         struct common_type<void, A>
         {
-            using type = typename std::common_type<A>::type;
+            using type = A;
         };
 
         template <>

--- a/test/visitor.cpp
+++ b/test/visitor.cpp
@@ -118,6 +118,23 @@ TEST_CASE("visit variant")
         visit(visitor{-1}, a);
         visit(visitor{32}, a, b);
     }
+    SECTION("returning reference")
+    {
+        struct visitor
+        {
+            int  value;
+            int& operator()(int)
+            {
+                return value;
+            }
+        };
+
+        visitor      v{1};
+        variant<int> x{1};
+        visit(v, x) = 2;
+
+        REQUIRE(v.value == 2);
+    }
     SECTION("rarely empty variant")
     {
         struct visitor


### PR DESCRIPTION
@SuperV1234 pointed out that `type_safe::visit` wasn't able to return a reference.

Changing your custom `common_type` to decay its arguments only if they are different solves issue #48.

All the tests pass, and I couldn't think in a case that the changes would break the expected behavior.

I also run `clang-format` and it changed many lines in `type_safe/visitor.hpp`.
I decided to discard all changes not related to this pull request.