### PR TITLE
fixed typo of 'comparison'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ I highly suggest that you check out [the first](https://foonathan.github.io/blog
 * `ts::integer<T>` - a zero overhead wrapper over a built-in integer type
     * no default constructor to force meaningful initialization
     * no "lossy" conversions (i.e. from a bigger type or a type with a different signedness)
-    * no mixed arithmetic/comparision with floating points or integer types of a different signedness
+    * no mixed arithmetic/comparison with floating points or integer types of a different signedness
     * over/underflow is undefined behavior in release mode - even for `unsigned` integers,
       enabling compiler optimizations
 * `ts::floating_point<T>` - a zero overhead wrapper over a built-in floating point
     * no default constructor to force meaningful initialization
     * no "lossy"  conversion (i.e. from a bigger type)
-    * no "lossy" comparisions
-    * no mixed arithmetic/comparision with integers
+    * no "lossy" comparisons
+    * no mixed arithmetic/comparison with integers
 * `ts::boolean` - a zero overhead wrapper over `bool`
     * no default constructor to force meaningful initialization
     * no conversion from integer values

--- a/example/types.cpp
+++ b/example/types.cpp
@@ -88,7 +88,7 @@ int main()
     std::cout << "floating point value: " << f1 << ' ' << d1 << '\n';
 
     //    f1++;      // error: no in/decrement for floats
-    //    f1 == 0.f; // error: no equality comparision for floats
+    //    f1 == 0.f; // error: no equality comparison for floats
 
     //=== narrow cast ===//
     ts::uint32_t uint32_val(325_u32);

--- a/include/type_safe/boolean.hpp
+++ b/include/type_safe/boolean.hpp
@@ -85,7 +85,7 @@ namespace type_safe
         bool value_;
     };
 
-    //=== comparision ===//
+    //=== comparison ===//
     /// [ts::boolean]() equality comparison.
     /// \returns `true` if (1) both [ts::boolean]() objects have the same value,
     /// (2)/(3) the boolean has the same value as the given value,

--- a/include/type_safe/floating_point.hpp
+++ b/include/type_safe/floating_point.hpp
@@ -36,19 +36,19 @@ namespace type_safe
             typename std::enable_if<!is_safe_floating_point_conversion<From, To>::value>::type;
 
         template <typename A, typename B>
-        struct is_safe_floating_point_comparision
+        struct is_safe_floating_point_comparison
         : std::integral_constant<bool, is_safe_floating_point_conversion<A, B>::value
                                            || is_safe_floating_point_conversion<B, A>::value>
         {
         };
 
         template <typename A, typename B>
-        using enable_safe_floating_point_comparision =
-            typename std::enable_if<is_safe_floating_point_comparision<A, B>::value>::type;
+        using enable_safe_floating_point_comparison =
+            typename std::enable_if<is_safe_floating_point_comparison<A, B>::value>::type;
 
         template <typename A, typename B>
-        using fallback_safe_floating_point_comparision =
-            typename std::enable_if<!is_safe_floating_point_comparision<A, B>::value>::type;
+        using fallback_safe_floating_point_comparison =
+            typename std::enable_if<!is_safe_floating_point_comparison<A, B>::value>::type;
 
         template <typename A, typename B>
         struct is_safe_floating_point_operation
@@ -253,7 +253,7 @@ namespace type_safe
         floating_point_type value_;
     };
 
-//=== comparision ===//
+//=== comparison ===//
 /// \exclude
 #define TYPE_SAFE_DETAIL_MAKE_OP(Op)                                                               \
     /** \group float_comp
@@ -269,22 +269,22 @@ namespace type_safe
      * \param 2
      * \exclude  */                                                                          \
     template <typename A, typename B,                                                              \
-              typename = detail::enable_safe_floating_point_comparision<A, B>>                     \
+              typename = detail::enable_safe_floating_point_comparison<A, B>>                     \
     TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const floating_point<A>& a, const B& b)      \
     {                                                                                              \
         return a Op floating_point<B>(b);                                                          \
     }                                                                                              \
     /** \exclude */                                                                                \
     template <typename A, typename B,                                                              \
-              typename = detail::fallback_safe_floating_point_comparision<A, B>>                   \
+              typename = detail::fallback_safe_floating_point_comparison<A, B>>                   \
     constexpr bool operator Op(floating_point<A>, floating_point<B>) = delete;                     \
     /** \exclude */                                                                                \
     template <typename A, typename B,                                                              \
-              typename = detail::fallback_safe_floating_point_comparision<A, B>>                   \
+              typename = detail::fallback_safe_floating_point_comparison<A, B>>                   \
     constexpr bool operator Op(A, floating_point<B>) = delete;                                     \
     /** \exclude */                                                                                \
     template <typename A, typename B,                                                              \
-              typename = detail::fallback_safe_floating_point_comparision<A, B>>                   \
+              typename = detail::fallback_safe_floating_point_comparison<A, B>>                   \
     constexpr bool operator Op(floating_point<A>, B) = delete;
 
     /// \returns The result of the comparison of the stored floating point value in the [ts::floating_point]().
@@ -295,7 +295,7 @@ namespace type_safe
     /// \param 2
     /// \exclude
     template <typename A, typename B,
-              typename = detail::enable_safe_floating_point_comparision<A, B>>
+              typename = detail::enable_safe_floating_point_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator<(const floating_point<A>& a,
                                                     const floating_point<B>& b) noexcept
     {
@@ -307,7 +307,7 @@ namespace type_safe
     /// \param 2
     /// \exclude
     template <typename A, typename B,
-              typename = detail::enable_safe_floating_point_comparision<A, B>>
+              typename = detail::enable_safe_floating_point_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator<=(const floating_point<A>& a,
                                                      const floating_point<B>& b) noexcept
     {
@@ -319,7 +319,7 @@ namespace type_safe
     /// \param 2
     /// \exclude
     template <typename A, typename B,
-              typename = detail::enable_safe_floating_point_comparision<A, B>>
+              typename = detail::enable_safe_floating_point_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator>(const floating_point<A>& a,
                                                     const floating_point<B>& b) noexcept
     {
@@ -331,7 +331,7 @@ namespace type_safe
     /// \param 2
     /// \exclude
     template <typename A, typename B,
-              typename = detail::enable_safe_floating_point_comparision<A, B>>
+              typename = detail::enable_safe_floating_point_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator>=(const floating_point<A>& a,
                                                      const floating_point<B>& b) noexcept
     {

--- a/include/type_safe/integer.hpp
+++ b/include/type_safe/integer.hpp
@@ -47,19 +47,19 @@ namespace type_safe
             typename std::enable_if<!is_safe_integer_conversion<From, To>::value>::type;
 
         template <typename A, typename B>
-        struct is_safe_integer_comparision
+        struct is_safe_integer_comparison
         : std::integral_constant<bool, is_safe_integer_conversion<A, B>::value
                                            || is_safe_integer_conversion<B, A>::value>
         {
         };
 
         template <typename A, typename B>
-        using enable_safe_integer_comparision =
-            typename std::enable_if<is_safe_integer_comparision<A, B>::value>::type;
+        using enable_safe_integer_comparison =
+            typename std::enable_if<is_safe_integer_comparison<A, B>::value>::type;
 
         template <typename A, typename B>
-        using fallback_safe_integer_comparision =
-            typename std::enable_if<!is_safe_integer_comparision<A, B>::value>::type;
+        using fallback_safe_integer_comparison =
+            typename std::enable_if<!is_safe_integer_comparison<A, B>::value>::type;
 
         template <typename A, typename B>
         struct is_safe_integer_operation
@@ -454,7 +454,7 @@ namespace type_safe
      * \param 3
      * \exclude */                                                                            \
     template <typename A, typename B, class Policy,                                                \
-              typename = detail::enable_safe_integer_comparision<A, B>>                            \
+              typename = detail::enable_safe_integer_comparison<A, B>>                            \
     TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const A& a, const integer<B, Policy>& b)     \
     {                                                                                              \
         return integer<A, Policy>(a) Op b;                                                         \
@@ -463,22 +463,22 @@ namespace type_safe
      * \param 3
      * \exclude */                                                                            \
     template <typename A, class Policy, typename B,                                                \
-              typename = detail::enable_safe_integer_comparision<A, B>>                            \
+              typename = detail::enable_safe_integer_comparison<A, B>>                            \
     TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const integer<A, Policy>& a, const B& b)     \
     {                                                                                              \
         return a Op integer<B, Policy>(b);                                                         \
     }                                                                                              \
     /** \exclude */                                                                                \
     template <typename A, class Policy, typename B,                                                \
-              typename = detail::fallback_safe_integer_comparision<A, B>>                          \
+              typename = detail::fallback_safe_integer_comparison<A, B>>                          \
     constexpr bool operator Op(integer<A, Policy>, integer<B, Policy>) = delete;                   \
     /** \exclude */                                                                                \
     template <typename A, typename B, class Policy,                                                \
-              typename = detail::fallback_safe_integer_comparision<A, B>>                          \
+              typename = detail::fallback_safe_integer_comparison<A, B>>                          \
     constexpr bool operator Op(A, integer<B, Policy>) = delete;                                    \
     /** \exclude */                                                                                \
     template <typename A, class Policy, typename B,                                                \
-              typename = detail::fallback_safe_integer_comparision<A, B>>                          \
+              typename = detail::fallback_safe_integer_comparison<A, B>>                          \
     constexpr bool operator Op(integer<A, Policy>, B) = delete;
 
     /// \returns The result of the comparison of the stored integer value in the [ts::integer]().
@@ -489,7 +489,7 @@ namespace type_safe
     /// \param 3
     /// \exclude
     template <typename A, typename B, class Policy,
-              typename = detail::enable_safe_integer_comparision<A, B>>
+              typename = detail::enable_safe_integer_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator==(const integer<A, Policy>& a,
                                                      const integer<B, Policy>& b)
     {
@@ -501,7 +501,7 @@ namespace type_safe
     /// \param 3
     /// \exclude
     template <typename A, typename B, class Policy,
-              typename = detail::enable_safe_integer_comparision<A, B>>
+              typename = detail::enable_safe_integer_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator!=(const integer<A, Policy>& a,
                                                      const integer<B, Policy>& b)
     {
@@ -513,7 +513,7 @@ namespace type_safe
     /// \param 3
     /// \exclude
     template <typename A, typename B, class Policy,
-              typename = detail::enable_safe_integer_comparision<A, B>>
+              typename = detail::enable_safe_integer_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator<(const integer<A, Policy>& a,
                                                     const integer<B, Policy>& b)
     {
@@ -525,7 +525,7 @@ namespace type_safe
     /// \param 3
     /// \exclude
     template <typename A, typename B, class Policy,
-              typename = detail::enable_safe_integer_comparision<A, B>>
+              typename = detail::enable_safe_integer_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator<=(const integer<A, Policy>& a,
                                                      const integer<B, Policy>& b)
     {
@@ -537,7 +537,7 @@ namespace type_safe
     /// \param 3
     /// \exclude
     template <typename A, typename B, class Policy,
-              typename = detail::enable_safe_integer_comparision<A, B>>
+              typename = detail::enable_safe_integer_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator>(const integer<A, Policy>& a,
                                                     const integer<B, Policy>& b)
     {
@@ -549,7 +549,7 @@ namespace type_safe
     /// \param 3
     /// \exclude
     template <typename A, typename B, class Policy,
-              typename = detail::enable_safe_integer_comparision<A, B>>
+              typename = detail::enable_safe_integer_comparison<A, B>>
     TYPE_SAFE_FORCE_INLINE constexpr bool operator>=(const integer<A, Policy>& a,
                                                      const integer<B, Policy>& b)
     {

--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -27,7 +27,7 @@ namespace type_safe
     /// ```cpp
     /// struct my_handle
     /// : strong_typedef<my_handle, void*>,
-    ///   strong_typedef_op::equality_comparision<my_handle>
+    ///   strong_typedef_op::equality_comparison<my_handle>
     /// {
     ///     using strong_typedef::strong_typedef;
     /// };
@@ -35,8 +35,8 @@ namespace type_safe
     /// struct my_int
     /// : strong_typedef<my_int, int>,
     ///   strong_typedef_op::integer_arithmetic<my_int>,
-    ///   strong_typedef_op::equality_comparision<my_int>,
-    ///   strong_typedef_op::relational_comparision<my_int>
+    ///   strong_typedef_op::equality_comparison<my_int>,
+    ///   strong_typedef_op::relational_comparison<my_int>
     /// {
     ///     using strong_typedef::strong_typedef;
     /// };

--- a/test/boolean.cpp
+++ b/test/boolean.cpp
@@ -45,7 +45,7 @@ TEST_CASE("boolean")
         boolean b2(false);
         REQUIRE(!b2 == true);
     }
-    SECTION("comparision")
+    SECTION("comparison")
     {
         boolean b1(true);
         REQUIRE(b1 == true);

--- a/test/floating_point.cpp
+++ b/test/floating_point.cpp
@@ -140,7 +140,7 @@ TEST_CASE("floating_point")
         normal  = -11.0 / normal;
         REQUIRE(static_cast<double>(wrapper) == normal);
     }
-    SECTION("comparision")
+    SECTION("comparison")
     {
         // <
         REQUIRE(bool(float_t(4.) < float_t(5.)));

--- a/test/integer.cpp
+++ b/test/integer.cpp
@@ -189,7 +189,7 @@ TEST_CASE("integer")
         normal  = (-4) % normal;
         REQUIRE(static_cast<int>(wrapper) == normal);
     }
-    SECTION("comparision")
+    SECTION("comparison")
     {
         // ==
         REQUIRE(bool(int_t(4) == int_t(4)));

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -340,7 +340,7 @@ TEST_CASE("optional")
         REQUIRE(a.has_value());
         REQUIRE(a.value() == 1);
     }
-    SECTION("comparision")
+    SECTION("comparison")
     {
         optional<int> a;
         optional<int> b(1);


### PR DESCRIPTION

The code mix use of 'comparision' and 'comparison', may be a typo?