### PR TITLE
Use GNUC macro only to check for is_trivially_copyable support

### DIFF
--- a/include/type_safe/tagged_union.hpp
+++ b/include/type_safe/tagged_union.hpp
@@ -89,7 +89,7 @@ namespace type_safe
     template <typename... Types>
     class tagged_union
     {
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && __GNUC__ < 5
         // does not have is_trivially_copyable
         using trivial = detail::all_of<std::is_trivial<Types>::value...>;
 #else


### PR DESCRIPTION
Basically, don't assume builds using clang could not use the GNU stdlibc++ standard library. Found when setting up the CI build to report https://github.com/foonathan/cppast/issues/33 :)

[Here](https://gitlab.com/Manu343726/tinyrefl/pipelines/16560927)'s a `type_safe_stdlibcxx_istriviallycopyable_trait` branch CI build that reproduces the problem (As with cppast 33, using the `geordiejones/cpp14-build-machine` docker image to build cppast with Clang 5.0).