### PR TITLE
Support mixed operators with other strong typedefs and noncommutative mixed operators

### DIFF
--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -286,7 +286,7 @@ namespace type_safe
     }
 
 /// \exclude
-#define TYPE_SAFE_DETAIL_MAKE_OP_MIXED(Op, Name, Result)                                           \
+#define TYPE_SAFE_DETAIL_MAKE_OP_STRONGTYPEDEF_OTHER(Op, Name, Result)                             \
     /** \exclude */                                                                                \
     template <class StrongTypedef, typename OtherArg, typename Other,                              \
               typename = detail::enable_if_convertible_same<Other&&, OtherArg>>                    \
@@ -302,7 +302,9 @@ namespace type_safe
     {                                                                                              \
         return Result(get(static_cast<StrongTypedef&&>(lhs))                                       \
             Op detail::forward_or_underlying(detail::forward<Other>(rhs)));                        \
-    }                                                                                              \
+    }
+
+#define TYPE_SAFE_DETAIL_MAKE_OP_OTHER_STRONGTYPEDEF(Op, Name, Result)                             \
     /** \exclude */                                                                                \
     template <class StrongTypedef, typename OtherArg, typename Other,                              \
               typename = detail::enable_if_convertible_same<Other&&, OtherArg>>                    \
@@ -319,6 +321,10 @@ namespace type_safe
         return Result(detail::forward_or_underlying(detail::forward<Other>(lhs))                   \
             Op get(static_cast<StrongTypedef&&>(rhs)));                                            \
     }
+
+#define TYPE_SAFE_DETAIL_MAKE_OP_MIXED(Op, Name, Result)                                           \
+    TYPE_SAFE_DETAIL_MAKE_OP_STRONGTYPEDEF_OTHER(Op, Name, Result)                                 \
+    TYPE_SAFE_DETAIL_MAKE_OP_OTHER_STRONGTYPEDEF(Op, Name, Result)
 
 /// \exclude
 #define TYPE_SAFE_DETAIL_MAKE_OP_COMPOUND(Op, Name)                                                \
@@ -412,7 +418,13 @@ namespace type_safe
     {                                                                                              \
     };                                                                                             \
     TYPE_SAFE_DETAIL_MAKE_OP_MIXED(Op, mixed_##Name, StrongTypedef)                                \
-    TYPE_SAFE_DETAIL_MAKE_OP_COMPOUND_MIXED(Op## =, mixed_##Name)
+    TYPE_SAFE_DETAIL_MAKE_OP_COMPOUND_MIXED(Op## =, mixed_##Name)                                  \
+    template <class StrongTypedef, typename Other>                                                 \
+    struct mixed_##Name##_noncommutative                                                           \
+    {                                                                                              \
+    };                                                                                             \
+    TYPE_SAFE_DETAIL_MAKE_OP_STRONGTYPEDEF_OTHER(Op, mixed_##Name##_noncommutative, StrongTypedef) \
+    TYPE_SAFE_DETAIL_MAKE_OP_COMPOUND_MIXED(Op## =, mixed_##Name##_noncommutative)
 
         template <class StrongTypedef>
         struct equality_comparison
@@ -755,6 +767,8 @@ namespace type_safe
 
 #undef TYPE_SAFE_DETAIL_MAKE_OP
 #undef TYPE_SAFE_DETAIL_MAKE_OP_MIXED
+#undef TYPE_SAFE_DETAIL_MAKE_OP_STRONGTYPEDEF_OTHER
+#undef TYPE_SAFE_DETAIL_MAKE_OP_OTHER_STRONGTYPEDEF
 #undef TYPE_SAFE_DETAIL_MAKE_OP_COMPOUND
 #undef TYPE_SAFE_DETAIL_MAKE_STRONG_TYPEDEF_OP
     } // namespace strong_typedef_op

--- a/test/strong_typedef.cpp
+++ b/test/strong_typedef.cpp
@@ -296,6 +296,28 @@ TEST_CASE("strong_typedef")
         b = 1 - b;
         REQUIRE(static_cast<int>(b) == 3);
     }
+    SECTION("subtraction noncommutative")
+    {
+        struct type : strong_typedef<type, int>,
+                      strong_typedef_op::subtraction<type>,
+                      strong_typedef_op::mixed_subtraction_noncommutative<type, int>
+        {
+            using strong_typedef::strong_typedef;
+        };
+
+        type a(0);
+        a -= type(1);    // -1
+        a = a - type(1); // -2
+        a = type(1) - a; // 3
+        REQUIRE(static_cast<int>(a) == 3);
+
+        type b(0);
+        b -= 1;
+        b = b - 1;
+        REQUIRE(static_cast<int>(b) == -2);
+        static_assert(is_operator_minus_callable_with<type, int>::value, "");
+        static_assert(!is_operator_minus_callable_with<int, type>::value, "type is noncommutative");
+    }
     SECTION("multiplication")
     {
         struct type : strong_typedef<type, int>,
@@ -337,6 +359,29 @@ TEST_CASE("strong_typedef")
         b = b / 2;
         b = 2 / b;
         REQUIRE(static_cast<int>(b) == 1);
+    }
+    SECTION("division noncommutative")
+    {
+        struct type : strong_typedef<type, int>,
+                      strong_typedef_op::division<type>,
+                      strong_typedef_op::mixed_division_noncommutative<type, int>
+        {
+            using strong_typedef::strong_typedef;
+        };
+
+        type a(8);
+        a /= type(2);
+        a = a / type(2);
+        a = type(2) / a;
+        REQUIRE(static_cast<int>(a) == 1);
+
+        type b(8);
+        b /= 2;
+        b = b / 2;
+        REQUIRE(static_cast<int>(b) == 2);
+        static_assert(is_division_callable_with<type, int>::value, "");
+        static_assert(!is_division_callable_with<int, type>::value,
+                      "division of type and int is noncommutative");
     }
     SECTION("modulo")
     {


### PR DESCRIPTION
The first commit enables 'mixed' operators with other strong_typedefs, by applying the operator on the underlying type of _both_ strong_typedefs.

The second commits adds noncommutative mixed operators, useful for subtraction and division.

Use case demonstrating both cases:
```cpp
struct year_offset : strong_typedef<year_offset, int> {};
struct year : strong_typedef<year, int>,
              mixed_subtraction_noncommutative<year, year_offset> {};
year y2018(2018);
year_offset o(3);
year y2015 = y2018 - offset; // OK, creates a year-object by subtracting the underlying values of both strong_typedefs
offset - y2018; // compile error, operator not found.
```