### PR TITLE
Make the use of the `hashable` base C++17 compliant

### DIFF
--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -776,7 +776,7 @@ namespace type_safe
     /// Inherit from it in the `std::hash<StrongTypedef>` specialization to make
     /// it hashable like the underlying type. See example/strong_typedef.cpp.
     template <class StrongTypedef>
-    struct hashable
+    struct hashable : std::hash<type_safe::underlying_type<StrongTypedef>>
     {
         using underlying_type = type_safe::underlying_type<StrongTypedef>;
         using underlying_hash = std::hash<underlying_type>;


### PR DESCRIPTION
By inheriting from the respective `std::hash`, the use of `type_safe::`~~`strong_typedef_op::`~~`hashable` meets the [C++17 requirements](https://wg21.link/unord.hash#4) when using C++17. When first implementing it, I thought the current implementation was enough from reading the non-normative note just above the linked paragraph.