### PR TITLE
Change logic to enable tests for dependent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 # only add if not inside add_subdirectory()
 option(TYPE_SAFE_BUILD_TEST_EXAMPLE "build test and example" OFF)
 option(BUILD_TESTING "build test and example" OFF) # The ctest variable for building tests
-if(${TYPE_SAFE_BUILD_TEST_EXAMPLE} OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR) OR ${BUILD_TESTING})
+if(${TYPE_SAFE_BUILD_TEST_EXAMPLE} OR ((CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR) AND ${BUILD_TESTING}))
     enable_testing()
     add_subdirectory(example/)
     add_subdirectory(test/)


### PR DESCRIPTION
Similar to https://github.com/foonathan/cppast/pull/63

Relying on the ctest variable only to enable type_safe tests does not work if some upper project depending on type_safe is working with ctest. I want to test my library, not yours :P

This changes the logic a bit to only follow the ctest variable if building type_safe as a root cmake project.