### PR TITLE
Workaround for compiling with MSVC /permissive-

### DIFF
--- a/include/type_safe/tagged_union.hpp
+++ b/include/type_safe/tagged_union.hpp
@@ -286,8 +286,10 @@ namespace type_safe
         private:
             template <typename T>
             static auto call(int, Union&& u, Func&& func, Args&&... args)
+#if !defined(_MSC_VER) || _MSC_VER < 1900
                 -> decltype(std::forward<Func>(func)(std::forward<Union>(u).value(union_type<T>{}),
                                                      std::forward<Args>(args)...))
+#endif
             {
                 return std::forward<Func>(func)(std::forward<Union>(u).value(union_type<T>{}),
                                                 std::forward<Args>(args)...);


### PR DESCRIPTION
There is a bug in MSVC ( https://godbolt.org/z/CZZvY3 ) due to which this code doesn't compile with the /permissive- option. Without /permissive- it compiles but then other things like ranges-v3 need /permissive- to compile. The auto return type deduction feature was added in Visual Studio 2015 (_MSC_VER 1900), so as a workaround we can just omit the trailing return type in newer versions and it works.