### PR TITLE
Fix strong_typedef_op::iterator type aliases

### DIFF
--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -10,7 +10,6 @@
 #include <type_traits>
 #include <utility>
 
-#include <type_safe/detail/all_of.hpp>
 #include <type_safe/config.hpp>
 
 namespace type_safe
@@ -670,8 +669,8 @@ namespace type_safe
         struct iterator : dereference<StrongTypedef, T, T*, const T*>, increment<StrongTypedef>
         {
             using iterator_category = Category;
-            using value_type        = T;
-            using distance_type     = Distance;
+            using value_type        = typename std::remove_cv<T>::type;
+            using difference_type   = Distance;
             using pointer           = T*;
             using reference         = T&;
         };


### PR DESCRIPTION
1) difference_type  is misnamed distance_type.
   iterator doesn't have a distance_type.
2) value_type should have const removed if T is const.
   Otherwise some of the STL algorithms don't work
   (e.g. partial_sum). std::vector's iterator does this
   for all C++ versions and std::iterator_traits have
   it fixed for C++20.

Unrelated issue (too minor too be worthy of it's own
commit): all_of.hpp header isn't needed.