### PR TITLE
Fix ambiguous call to forward

### DIFF
--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -219,7 +219,7 @@ namespace strong_typedef_op
         constexpr typename std::enable_if<!is_strong_typedef<T>::value, T&&>::type
             forward_or_underlying(T&& type) noexcept
         {
-            return forward<T>(type);
+            return detail::forward<T>(type);
         }
     } // namespace detail
 


### PR DESCRIPTION
When trying to use `strong_typedef` with `std::string`, I got this ambiguous call error with `forward` defined both in `std` and `strong_typedef_op::detail`.

```
error C2668: 'type_safe::strong_typedef_op::detail::forward': ambiguous call to overloaded function
  include\type_safe/strong_typedef.hpp(180): note: could be 'T &&type_safe::strong_typedef_op::detail::forward<Other>(std::basic_string<char,std::char_traits<char>,std::allocator<char>> &) noexcept'
          with
          [
              T=std::basic_string<char,std::char_traits<char>,std::allocator<char>>,
              Other=std::basic_string<char,std::char_traits<char>,std::allocator<char>>
          ]
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.24.28314\include\type_traits(1425): note: or       '_Ty &&std::forward<_Ty1>(std::basic_string<char,std::char_traits<char>,std::allocator<char>> &) noexcept' [found using argument-dependent lookup]
```

 This can be easily fixed though. Tested with an up-to-date MSVC 2019.