### PR TITLE
Cmake test fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ endif()
 # other subdirectories
 # only add if not inside add_subdirectory()
 option(TYPE_SAFE_BUILD_TEST_EXAMPLE "build test and example" OFF)
-if(${TYPE_SAFE_BUILD_TEST_EXAMPLE} OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR))
+if(TYPE_SAFE_BUILD_TEST_EXAMPLE)
     enable_testing()
     add_subdirectory(example/)
     add_subdirectory(test/)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp)
     file(DOWNLOAD
-         https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch2/catch.hpp
+         https://github.com/catchorg/Catch2/releases/download/v2.13.3/catch.hpp
          ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp
          STATUS status
          LOG log)


### PR DESCRIPTION
This PR fixes the ability to control building examples and tests using CMake.

1. The root project condition is removed from the test build logic as mentioned at #116.
2. Failing Catch2 download link is updated. Also mentioned at #116.