### PR TITLE
Update `strong_typedef` to be structural.

### DIFF
--- a/include/type_safe/strong_typedef.hpp
+++ b/include/type_safe/strong_typedef.hpp
@@ -91,7 +91,6 @@ public:
         swap(static_cast<T&>(a), static_cast<T&>(b));
     }
 
-private:
     T value_;
 };
 


### PR DESCRIPTION
Switching `value_` from `private` to `public` make `strong_typdef` structural
and thus usable in Class Non-Type Template Parameter context in C++20 and
above.

Addresses #125.