### PR TITLE
replaced is_pod in test project

### DIFF
--- a/test/boolean.cpp
+++ b/test/boolean.cpp
@@ -11,7 +11,8 @@
 using namespace type_safe;
 
 #ifndef TYPE_SAFE_TEST_NO_STATIC_ASSERT
-static_assert(std::is_pod<boolean>::value, "");
+static_assert(std::is_standard_layout<boolean>::value, "");
+static_assert(std::is_trivially_copyable<boolean>::value, "");
 // conversion checks
 static_assert(std::is_constructible<boolean, bool>::value, "");
 static_assert(!std::is_constructible<boolean, int>::value, "");


### PR DESCRIPTION
Replaced `is_pod` in test/boolean.cpp with `is_standard_layout` and `is_trivially_copyable`.

The same static asserts are already in test/integer.cpp and test/floating_point.cpp, now it is consistent across all files.