### PR TITLE
Implement safe integer comparison similar to P0586R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ I highly suggest that you check out [the first](https://www.foonathan.net/2016/1
 * `ts::integer<T>` - a zero overhead wrapper over a built-in integer type
     * no default constructor to force meaningful initialization
     * no "lossy" conversions (i.e. from a bigger type or a type with a different signedness)
-    * no mixed arithmetic/comparison with floating points or integer types of a different signedness
+    * no mixed arithmetic with floating points or integer types of a different signedness
+    * no mixed comparison with floating points
     * over/underflow is undefined behavior in release mode - even for `unsigned` integers,
       enabling compiler optimizations
 * `ts::floating_point<T>` - a zero overhead wrapper over a built-in floating point

--- a/include/type_safe/integer.hpp
+++ b/include/type_safe/integer.hpp
@@ -53,14 +53,6 @@ namespace detail
     {};
 
     template <typename A, typename B>
-    using enable_safe_integer_comparison =
-        typename std::enable_if<is_safe_integer_comparison<A, B>::value>::type;
-
-    template <typename A, typename B>
-    using fallback_safe_integer_comparison =
-        typename std::enable_if<!is_safe_integer_comparison<A, B>::value>::type;
-
-    template <typename A, typename B>
     struct is_safe_integer_operation
     : std::integral_constant<bool, detail::is_integer<A>::value && detail::is_integer<B>::value
                                        && std::is_signed<A>::value == std::is_signed<B>::value>
@@ -459,9 +451,10 @@ namespace detail
 {
     // A signed, B unsigned
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_equal_unsafe_impl(
-        const integer<A, Policy>& a, const integer<B, Policy>& b, std::true_type,
-        std::false_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_equal_unsafe_impl(const integer<A, Policy>& a,
+                                                                const integer<B, Policy>& b,
+                                                                std::true_type,
+                                                                std::false_type) noexcept
     {
         using UA = typename make_unsigned<A>::type;
         return static_cast<A>(a) < 0 ? false : UA(static_cast<A>(a)) == static_cast<B>(b);
@@ -469,9 +462,10 @@ namespace detail
 
     // A unsigned, B signed
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_equal_unsafe_impl(
-        const integer<A, Policy>& a, const integer<B, Policy>& b, std::false_type,
-        std::true_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_equal_unsafe_impl(const integer<A, Policy>& a,
+                                                                const integer<B, Policy>& b,
+                                                                std::false_type,
+                                                                std::true_type) noexcept
     {
         using UB = typename make_unsigned<B>::type;
         return static_cast<B>(b) < 0 ? false : UB(static_cast<B>(b)) == static_cast<A>(a);
@@ -479,27 +473,28 @@ namespace detail
 
     // A and B same signedness
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_equal_impl(const integer<A, Policy>& a,
-                                                                     const integer<B, Policy>& b,
-                                                                     std::true_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_equal_impl(const integer<A, Policy>& a,
+                                                         const integer<B, Policy>& b,
+                                                         std::true_type) noexcept
     {
         return static_cast<A>(a) == static_cast<B>(b);
     }
 
     // A and B different signedness
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_equal_impl(const integer<A, Policy>& a,
-                                                                     const integer<B, Policy>& b,
-                                                                     std::false_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_equal_impl(const integer<A, Policy>& a,
+                                                         const integer<B, Policy>& b,
+                                                         std::false_type) noexcept
     {
         return cmp_equal_unsafe_impl(a, b, std::is_signed<A>(), std::is_signed<B>());
     }
 
     // A signed, B unsigned
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_less_unsafe_impl(
-        const integer<A, Policy>& a, const integer<B, Policy>& b, std::true_type,
-        std::false_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_less_unsafe_impl(const integer<A, Policy>& a,
+                                                               const integer<B, Policy>& b,
+                                                               std::true_type,
+                                                               std::false_type) noexcept
     {
         using UA = typename make_unsigned<A>::type;
         return static_cast<A>(a) < 0 ? true : UA(static_cast<A>(a)) < static_cast<B>(b);
@@ -507,9 +502,10 @@ namespace detail
 
     // A unsigned, B signed
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_less_unsafe_impl(
-        const integer<A, Policy>& a, const integer<B, Policy>& b, std::false_type,
-        std::true_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_less_unsafe_impl(const integer<A, Policy>& a,
+                                                               const integer<B, Policy>& b,
+                                                               std::false_type,
+                                                               std::true_type) noexcept
     {
         using UB = typename make_unsigned<B>::type;
         return static_cast<B>(b) < 0 ? false : static_cast<A>(a) < UB(static_cast<B>(b));
@@ -517,18 +513,18 @@ namespace detail
 
     // A and B same signedness
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_less_impl(const integer<A, Policy>& a,
-                                                                    const integer<B, Policy>& b,
-                                                                    std::true_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_less_impl(const integer<A, Policy>& a,
+                                                        const integer<B, Policy>& b,
+                                                        std::true_type) noexcept
     {
         return static_cast<A>(a) < static_cast<B>(b);
     }
 
     // A and B different signedness
     template <typename A, typename B, class Policy>
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_less_impl(const integer<A, Policy>& a,
-                                                                    const integer<B, Policy>& b,
-                                                                    std::false_type) noexcept
+    TYPE_SAFE_FORCE_INLINE constexpr bool cmp_less_impl(const integer<A, Policy>& a,
+                                                        const integer<B, Policy>& b,
+                                                        std::false_type) noexcept
     {
         return cmp_less_unsafe_impl(a, b, std::is_signed<A>(), std::is_signed<B>());
     }
@@ -536,129 +532,36 @@ namespace detail
 } // namespace detail
 
 /// \exclude
-#define TYPE_SAFE_DETAIL_MAKE_FUNC(FUNC)                                                           \
+#define TYPE_SAFE_DETAIL_MAKE_OP(Op)                                                               \
     /** \group int_comp                                                                            \
      * \param 2                                                                                    \
      * \exclude */                                                                                 \
     template <typename A, typename B, class Policy>                                                \
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool FUNC(const A&                  a,            \
-                                                           const integer<B, Policy>& b) noexcept   \
+    TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const A&                  a,                 \
+                                                      const integer<B, Policy>& b) noexcept        \
     {                                                                                              \
-        return FUNC(integer<A, Policy>(a), b);                                                     \
+        return integer<A, Policy>(a) Op b;                                                         \
     }                                                                                              \
     /** \group int_comp                                                                            \
      * \param 2                                                                                    \
      * \exclude */                                                                                 \
     template <typename A, class Policy, typename B>                                                \
-    TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool FUNC(const integer<A, Policy>& a,            \
-                                                           const B&                  b) noexcept                    \
+    TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const integer<A, Policy>& a,                 \
+                                                      const B&                  b) noexcept                         \
     {                                                                                              \
-        return FUNC(a, integer<B, Policy>(b));                                                     \
+        return a Op integer<B, Policy>(b);                                                         \
     }
 
 /// \returns The result of the comparison of the stored integer value in the [ts::integer]().
 /// \notes These functions do not participate in overload resolution
 /// unless `A` and `B` are both integer types.
-/// \group int_comp Comparison functions
-/// \module types
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy>
-TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_equal(const integer<A, Policy>& a,
-                                                            const integer<B, Policy>& b) noexcept
-{
-    return detail::cmp_equal_impl(a, b, detail::is_safe_integer_comparison<A, B>());
-}
-TYPE_SAFE_DETAIL_MAKE_FUNC(cmp_equal)
-
-/// \group int_comp Comparison functions
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy>
-TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_not_equal(
-    const integer<A, Policy>& a, const integer<B, Policy>& b) noexcept
-{
-    return !detail::cmp_equal_impl(a, b, detail::is_safe_integer_comparison<A, B>());
-}
-TYPE_SAFE_DETAIL_MAKE_FUNC(cmp_not_equal)
-
-/// \group int_comp Comparison functions
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy>
-TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_less(const integer<A, Policy>& a,
-                                                           const integer<B, Policy>& b) noexcept
-{
-    return detail::cmp_less_impl(a, b, detail::is_safe_integer_comparison<A, B>());
-}
-TYPE_SAFE_DETAIL_MAKE_FUNC(cmp_less)
-
-/// \group int_comp Comparison functions
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy>
-TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_less_equal(
-    const integer<A, Policy>& a, const integer<B, Policy>& b) noexcept
-{
-    return !detail::cmp_less_impl(b, a, detail::is_safe_integer_comparison<A, B>());
-}
-TYPE_SAFE_DETAIL_MAKE_FUNC(cmp_less_equal)
-
-/// \group int_comp Comparison functions
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy>
-TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_greater(const integer<A, Policy>& a,
-                                                              const integer<B, Policy>& b) noexcept
-{
-    return detail::cmp_less_impl(b, a, detail::is_safe_integer_comparison<A, B>());
-}
-TYPE_SAFE_DETAIL_MAKE_FUNC(cmp_greater)
-
-/// \group int_comp Comparison functions
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy>
-TYPE_SAFE_FORCE_INLINE TYPE_SAFE_CONSTEXPR14 bool cmp_greater_equal(
-    const integer<A, Policy>& a, const integer<B, Policy>& b) noexcept
-{
-    return !detail::cmp_less_impl(a, b, detail::is_safe_integer_comparison<A, B>());
-}
-TYPE_SAFE_DETAIL_MAKE_FUNC(cmp_greater_equal)
-
-#undef TYPE_SAFE_DETAIL_MAKE_FUNC
-
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
-
-/// \exclude
-#    define TYPE_SAFE_DETAIL_MAKE_OP(Op)                                                           \
-        /** \group int_comp                                                                        \
-         * \param 2                                                                                \
-         * \exclude */                                                                             \
-        template <typename A, typename B, class Policy>                                            \
-        TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const A& a, const integer<B, Policy>& b) \
-        {                                                                                          \
-            return integer<A, Policy>(a) Op b;                                                     \
-        }                                                                                          \
-        /** \group int_comp                                                                        \
-         * \param 2                                                                                \
-         * \exclude */                                                                             \
-        template <typename A, class Policy, typename B>                                            \
-        TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const integer<A, Policy>& a, const B& b) \
-        {                                                                                          \
-            return a Op integer<B, Policy>(b);                                                     \
-        }
-
-/// \returns The result of the comparison of the stored integer value in the [ts::integer]().
-/// \notes These functions do not participate in overload resolution
-/// unless `A` and `B` are both integer types.
 /// \group int_comp Comparison operators
 /// \module types
 /// \param 2
 /// \exclude
 template <typename A, typename B, class Policy>
 TYPE_SAFE_FORCE_INLINE constexpr bool operator==(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
+                                                 const integer<B, Policy>& b) noexcept
 {
     return detail::cmp_equal_impl(a, b, detail::is_safe_integer_comparison<A, B>());
 }
@@ -669,7 +572,7 @@ TYPE_SAFE_DETAIL_MAKE_OP(==)
 /// \exclude
 template <typename A, typename B, class Policy>
 TYPE_SAFE_FORCE_INLINE constexpr bool operator!=(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
+                                                 const integer<B, Policy>& b) noexcept
 {
     return !detail::cmp_equal_impl(a, b, detail::is_safe_integer_comparison<A, B>());
 }
@@ -680,7 +583,7 @@ TYPE_SAFE_DETAIL_MAKE_OP(!=)
 /// \exclude
 template <typename A, typename B, class Policy>
 TYPE_SAFE_FORCE_INLINE constexpr bool operator<(const integer<A, Policy>& a,
-                                                const integer<B, Policy>& b)
+                                                const integer<B, Policy>& b) noexcept
 {
     return detail::cmp_less_impl(a, b, detail::is_safe_integer_comparison<A, B>());
 }
@@ -691,7 +594,7 @@ TYPE_SAFE_DETAIL_MAKE_OP(<)
 /// \exclude
 template <typename A, typename B, class Policy>
 TYPE_SAFE_FORCE_INLINE constexpr bool operator<=(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
+                                                 const integer<B, Policy>& b) noexcept
 {
     return !detail::cmp_less_impl(b, a, detail::is_safe_integer_comparison<A, B>());
 }
@@ -702,7 +605,7 @@ TYPE_SAFE_DETAIL_MAKE_OP(<=)
 /// \exclude
 template <typename A, typename B, class Policy>
 TYPE_SAFE_FORCE_INLINE constexpr bool operator>(const integer<A, Policy>& a,
-                                                const integer<B, Policy>& b)
+                                                const integer<B, Policy>& b) noexcept
 {
     return detail::cmp_less_impl(b, a, detail::is_safe_integer_comparison<A, B>());
 }
@@ -713,128 +616,13 @@ TYPE_SAFE_DETAIL_MAKE_OP(>)
 /// \exclude
 template <typename A, typename B, class Policy>
 TYPE_SAFE_FORCE_INLINE constexpr bool operator>=(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
+                                                 const integer<B, Policy>& b) noexcept
 {
     return !detail::cmp_less_impl(a, b, detail::is_safe_integer_comparison<A, B>());
 }
 TYPE_SAFE_DETAIL_MAKE_OP(>=)
 
-#    undef TYPE_SAFE_DETAIL_MAKE_OP
-
-#else // TYPE_SAFE_USE_CONSTEXPR14
-
-/// \exclude
-#    define TYPE_SAFE_DETAIL_MAKE_OP(Op)                                                           \
-        /** \group int_comp                                                                        \
-         * \param 2                                                                                \
-         * \exclude */                                                                             \
-        template <typename A, typename B, class Policy,                                            \
-                  typename = detail::enable_safe_integer_comparison<A, B>>                         \
-        TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const A& a, const integer<B, Policy>& b) \
-        {                                                                                          \
-            return integer<A, Policy>(a) Op b;                                                     \
-        }                                                                                          \
-        /** \group int_comp                                                                        \
-         * \param 2                                                                                \
-         * \exclude */                                                                             \
-        template <typename A, class Policy, typename B,                                            \
-                  typename = detail::enable_safe_integer_comparison<A, B>>                         \
-        TYPE_SAFE_FORCE_INLINE constexpr bool operator Op(const integer<A, Policy>& a, const B& b) \
-        {                                                                                          \
-            return a Op integer<B, Policy>(b);                                                     \
-        }                                                                                          \
-        /** \exclude */                                                                            \
-        template <typename A, class Policy, typename B,                                            \
-                  typename = detail::fallback_safe_integer_comparison<A, B>>                       \
-        constexpr bool operator Op(integer<A, Policy>, integer<B, Policy>) = delete;               \
-        /** \exclude */                                                                            \
-        template <typename A, typename B, class Policy,                                            \
-                  typename = detail::fallback_safe_integer_comparison<A, B>>                       \
-        constexpr bool operator Op(A, integer<B, Policy>) = delete;                                \
-        /** \exclude */                                                                            \
-        template <typename A, class Policy, typename B,                                            \
-                  typename = detail::fallback_safe_integer_comparison<A, B>>                       \
-        constexpr bool operator Op(integer<A, Policy>, B) = delete;
-
-/// \returns The result of the comparison of the stored integer value in the [ts::integer]().
-/// \notes These functions do not participate in overload resolution
-/// unless `A` and `B` are both integer types.
-/// \group int_comp Comparison operators
-/// \module types
-/// \param 3
-/// \exclude
-template <typename A, typename B, class Policy,
-          typename = detail::enable_safe_integer_comparison<A, B>>
-TYPE_SAFE_FORCE_INLINE constexpr bool operator==(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
-{
-    return static_cast<A>(a) == static_cast<B>(b);
-}
-TYPE_SAFE_DETAIL_MAKE_OP(==)
-
-/// \group int_comp Comparison operators
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy,
-          typename = detail::enable_safe_integer_comparison<A, B>>
-TYPE_SAFE_FORCE_INLINE constexpr bool operator!=(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
-{
-    return static_cast<A>(a) != static_cast<B>(b);
-}
-TYPE_SAFE_DETAIL_MAKE_OP(!=)
-
-/// \group int_comp Comparison operators
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy,
-          typename = detail::enable_safe_integer_comparison<A, B>>
-TYPE_SAFE_FORCE_INLINE constexpr bool operator<(const integer<A, Policy>& a,
-                                                const integer<B, Policy>& b)
-{
-    return static_cast<A>(a) < static_cast<B>(b);
-}
-TYPE_SAFE_DETAIL_MAKE_OP(<)
-
-/// \group int_comp Comparison operators
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy,
-          typename = detail::enable_safe_integer_comparison<A, B>>
-TYPE_SAFE_FORCE_INLINE constexpr bool operator<=(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
-{
-    return static_cast<A>(a) <= static_cast<B>(b);
-}
-TYPE_SAFE_DETAIL_MAKE_OP(<=)
-
-/// \group int_comp Comparison operators
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy,
-          typename = detail::enable_safe_integer_comparison<A, B>>
-TYPE_SAFE_FORCE_INLINE constexpr bool operator>(const integer<A, Policy>& a,
-                                                const integer<B, Policy>& b)
-{
-    return static_cast<A>(a) > static_cast<B>(b);
-}
-TYPE_SAFE_DETAIL_MAKE_OP(>)
-
-/// \group int_comp Comparison operators
-/// \param 2
-/// \exclude
-template <typename A, typename B, class Policy,
-          typename = detail::enable_safe_integer_comparison<A, B>>
-TYPE_SAFE_FORCE_INLINE constexpr bool operator>=(const integer<A, Policy>& a,
-                                                 const integer<B, Policy>& b)
-{
-    return static_cast<A>(a) >= static_cast<B>(b);
-}
-TYPE_SAFE_DETAIL_MAKE_OP(>=)
-
-#    undef TYPE_SAFE_DETAIL_MAKE_OP
-
-#endif // TYPE_SAFE_USE_CONSTEXPR14
+#undef TYPE_SAFE_DETAIL_MAKE_OP
 
 //=== binary operations ===//
 /// \entity TYPE_SAFE_DETAIL_MAKE_OP

--- a/test/integer.cpp
+++ b/test/integer.cpp
@@ -6,6 +6,7 @@
 
 #include <catch.hpp>
 
+#include <climits>
 #include <sstream>
 
 using namespace type_safe;
@@ -42,6 +43,7 @@ static_assert(!std::is_assignable<integer<unsigned>, int>::value, "");
 TEST_CASE("integer")
 {
     using int_t = integer<int>;
+    using uint_t = integer<unsigned int>;
 
     SECTION("constructor")
     {
@@ -212,77 +214,444 @@ TEST_CASE("integer")
     }
     SECTION("comparison")
     {
+        unsigned int u32_max = std::numeric_limits<unsigned int>::max();
+
         // ==
         REQUIRE(bool(int_t(4) == int_t(4)));
         REQUIRE(!(int_t(5) == int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(4u) == int_t(4)));
+        REQUIRE(!(uint_t(5u) == int_t(4)));
+        REQUIRE(!(uint_t(u32_max) == int_t(-1)));
+        REQUIRE(bool(int_t(4) == uint_t(4u)));
+        REQUIRE(!(int_t(5) == uint_t(4u)));
+        REQUIRE(!(int_t(-1) == uint_t(u32_max)));
+#endif
+        REQUIRE(cmp_equal(int_t(4), int_t(4)));
+        REQUIRE(!cmp_equal(int_t(5), int_t(4)));
+        REQUIRE(cmp_equal(uint_t(4u), int_t(4)));
+        REQUIRE(!cmp_equal(uint_t(5u), int_t(4)));
+        REQUIRE(!cmp_equal(uint_t(u32_max), int_t(-1)));
+        REQUIRE(cmp_equal(int_t(4), uint_t(4u)));
+        REQUIRE(!cmp_equal(int_t(5), uint_t(4u)));
+        REQUIRE(!cmp_equal(int_t(-1), uint_t(u32_max)));
 
         REQUIRE(bool(4 == int_t(4)));
         REQUIRE(!(5 == int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(4u == int_t(4)));
+        REQUIRE(!(5u == int_t(4)));
+        REQUIRE(!(u32_max == int_t(-1)));
+        REQUIRE(bool(4 == uint_t(4u)));
+        REQUIRE(!(5 == uint_t(4u)));
+        REQUIRE(!(-1 == uint_t(u32_max)));
+#endif
+        REQUIRE(cmp_equal(4, int_t(4)));
+        REQUIRE(!cmp_equal(5, int_t(4)));
+        REQUIRE(cmp_equal(4u, int_t(4)));
+        REQUIRE(!cmp_equal(5u, int_t(4)));
+        REQUIRE(!cmp_equal(u32_max, int_t(-1)));
+        REQUIRE(cmp_equal(4, uint_t(4u)));
+        REQUIRE(!cmp_equal(5, uint_t(4u)));
+        REQUIRE(!cmp_equal(-1, uint_t(u32_max)));
 
         REQUIRE(bool(int_t(4) == 4));
         REQUIRE(!(int_t(5) == 4));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(int_t(4) == 4u));
+        REQUIRE(!(int_t(5) == 4u));
+        REQUIRE(!(int_t(-1) == u32_max));
+        REQUIRE(bool(uint_t(4u) == 4));
+        REQUIRE(!(uint_t(5u) == 4));
+        REQUIRE(!(uint_t(u32_max) == -1));
+#endif
+        REQUIRE(cmp_equal(int_t(4), 4));
+        REQUIRE(!cmp_equal(int_t(5), 4));
+        REQUIRE(cmp_equal(int_t(4), 4u));
+        REQUIRE(!cmp_equal(int_t(5), 4u));
+        REQUIRE(!cmp_equal(int_t(-1), u32_max));
+        REQUIRE(cmp_equal(uint_t(4u), 4));
+        REQUIRE(!cmp_equal(uint_t(5u), 4));
+        REQUIRE(!cmp_equal(uint_t(u32_max), -1));
 
         // !=
         REQUIRE(bool(int_t(5) != int_t(4)));
         REQUIRE(!(int_t(4) != int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(5u) != int_t(4)));
+        REQUIRE(!(uint_t(4u) != int_t(4)));
+        REQUIRE(bool(uint_t(u32_max) != int_t(-1)));
+        REQUIRE(bool(int_t(5) != uint_t(4u)));
+        REQUIRE(!(int_t(4) != uint_t(4u)));
+        REQUIRE(bool(int_t(-1) != uint_t(u32_max)));
+#endif
+        REQUIRE(cmp_not_equal(int_t(5), int_t(4)));
+        REQUIRE(!cmp_not_equal(int_t(4), int_t(4)));
+        REQUIRE(cmp_not_equal(uint_t(5u), int_t(4)));
+        REQUIRE(!cmp_not_equal(uint_t(4u), int_t(4)));
+        REQUIRE(cmp_not_equal(uint_t(u32_max), int_t(-1)));
+        REQUIRE(cmp_not_equal(int_t(5), uint_t(4u)));
+        REQUIRE(!cmp_not_equal(int_t(4), uint_t(4u)));
+        REQUIRE(cmp_not_equal(int_t(-1), uint_t(u32_max)));
 
         REQUIRE(bool(5 != int_t(4)));
         REQUIRE(!(4 != int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(5u != int_t(4)));
+        REQUIRE(!(4u != int_t(4)));
+        REQUIRE(bool(u32_max != int_t(-1)));
+        REQUIRE(bool(5 != uint_t(4u)));
+        REQUIRE(!(4 != uint_t(4u)));
+        REQUIRE(bool(-1 != uint_t(u32_max)));
+#endif
+        REQUIRE(cmp_not_equal(5, int_t(4)));
+        REQUIRE(!cmp_not_equal(4, int_t(4)));
+        REQUIRE(cmp_not_equal(5u, int_t(4)));
+        REQUIRE(!cmp_not_equal(4u, int_t(4)));
+        REQUIRE(cmp_not_equal(u32_max, int_t(-1)));
+        REQUIRE(cmp_not_equal(5, uint_t(4u)));
+        REQUIRE(!cmp_not_equal(4, uint_t(4u)));
+        REQUIRE(cmp_not_equal(-1, uint_t(u32_max)));
 
         REQUIRE(bool(int_t(5) != 4));
         REQUIRE(!(int_t(4) != 4));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(int_t(5) != 4u));
+        REQUIRE(!(int_t(4) != 4u));
+        REQUIRE(bool(int_t(-1) != u32_max));
+        REQUIRE(bool(uint_t(5u) != 4));
+        REQUIRE(!(uint_t(4u) != 4));
+        REQUIRE(bool(uint_t(u32_max) != -1));
+#endif
+        REQUIRE(cmp_not_equal(int_t(5), 4));
+        REQUIRE(!cmp_not_equal(int_t(4), 4));
+        REQUIRE(cmp_not_equal(int_t(5), 4u));
+        REQUIRE(!cmp_not_equal(int_t(4), 4u));
+        REQUIRE(cmp_not_equal(int_t(-1), u32_max));
+        REQUIRE(cmp_not_equal(uint_t(5u), 4));
+        REQUIRE(!cmp_not_equal(uint_t(4u), 4));
+        REQUIRE(cmp_not_equal(uint_t(u32_max), -1));
 
         // <
         REQUIRE(bool(int_t(4) < int_t(5)));
         REQUIRE(!(int_t(5) < int_t(4)));
         REQUIRE(!(int_t(4) < int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(4u) < int_t(5)));
+        REQUIRE(!bool(uint_t(4u) < int_t(-5)));
+        REQUIRE(!(uint_t(5u) < int_t(4)));
+        REQUIRE(!(uint_t(4u) < int_t(4)));
+        REQUIRE(bool(int_t(4) < uint_t(5u)));
+        REQUIRE(bool(int_t(-4) < uint_t(5u)));
+        REQUIRE(!(int_t(5) < uint_t(4u)));
+        REQUIRE(!(int_t(4) < uint_t(4u)));
+#endif
+        REQUIRE(cmp_less(int_t(4), int_t(5)));
+        REQUIRE(!cmp_less(int_t(5), int_t(4)));
+        REQUIRE(!cmp_less(int_t(4), int_t(4)));
+        REQUIRE(cmp_less(uint_t(4u), int_t(5)));
+        REQUIRE(!cmp_less(uint_t(4u), int_t(-5)));
+        REQUIRE(!cmp_less(uint_t(5u), int_t(4)));
+        REQUIRE(!cmp_less(uint_t(4u), int_t(4)));
+        REQUIRE(cmp_less(int_t(4), uint_t(5u)));
+        REQUIRE(cmp_less(int_t(-4), uint_t(5u)));
+        REQUIRE(!cmp_less(int_t(5), uint_t(4u)));
+        REQUIRE(!cmp_less(int_t(4), uint_t(4u)));
 
         REQUIRE(bool(4 < int_t(5)));
         REQUIRE(!(5 < int_t(4)));
         REQUIRE(!(4 < int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(4u < int_t(5)));
+        REQUIRE(!bool(4u < int_t(-5)));
+        REQUIRE(!(5u < int_t(4)));
+        REQUIRE(!(4u < int_t(4)));
+        REQUIRE(bool(4 < uint_t(5u)));
+        REQUIRE(bool(-4 < uint_t(5u)));
+        REQUIRE(!(5 < uint_t(4u)));
+        REQUIRE(!(4 < uint_t(4u)));
+#endif
+        REQUIRE(cmp_less(4, int_t(5)));
+        REQUIRE(!cmp_less(5, int_t(4)));
+        REQUIRE(!cmp_less(4, int_t(4)));
+        REQUIRE(cmp_less(4u, int_t(5)));
+        REQUIRE(!cmp_less(4u, int_t(-5)));
+        REQUIRE(!cmp_less(5u, int_t(4)));
+        REQUIRE(!cmp_less(4u, int_t(4)));
+        REQUIRE(cmp_less(4, uint_t(5u)));
+        REQUIRE(cmp_less(-4, uint_t(5u)));
+        REQUIRE(!cmp_less(5, uint_t(4u)));
+        REQUIRE(!cmp_less(4, uint_t(4u)));
 
         REQUIRE(bool(int_t(4) < 5));
         REQUIRE(!(int_t(5) < 4));
         REQUIRE(!(int_t(4) < 4));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(int_t(4) < 5u));
+        REQUIRE(!(int_t(5) < 4u));
+        REQUIRE((int_t(-5) < 4u));
+        REQUIRE(!(int_t(4) < 4u));
+        REQUIRE(bool(uint_t(4u) < 5));
+        REQUIRE(!bool(uint_t(4u) < -5));
+        REQUIRE(!(uint_t(5u) < 4));
+        REQUIRE(!(uint_t(4u) < 4));
+#endif
+        REQUIRE(cmp_less(int_t(4), 5));
+        REQUIRE(!cmp_less(int_t(5), 4));
+        REQUIRE(!cmp_less(int_t(4), 4));
+        REQUIRE(cmp_less(int_t(4), 5u));
+        REQUIRE(!cmp_less(int_t(5), 4u));
+        REQUIRE(cmp_less(int_t(-5), 4u));
+        REQUIRE(!cmp_less(int_t(4), 4u));
+        REQUIRE(cmp_less(uint_t(4u), 5));
+        REQUIRE(!cmp_less(uint_t(4u), -5));
+        REQUIRE(!cmp_less(uint_t(5u), 4));
+        REQUIRE(!cmp_less(uint_t(4u), 4));
 
         // <=
         REQUIRE(bool(int_t(4) <= int_t(5)));
         REQUIRE(!(int_t(5) <= int_t(4)));
         REQUIRE(bool(int_t(4) <= int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(4u) <= int_t(5)));
+        REQUIRE(!(uint_t(4u) <= int_t(-5)));
+        REQUIRE(!(uint_t(5u) <= int_t(4)));
+        REQUIRE(bool(uint_t(4u) <= int_t(4)));
+        REQUIRE(bool(int_t(4) <= uint_t(5u)));
+        REQUIRE(!(int_t(5) <= uint_t(4u)));
+        REQUIRE(bool(int_t(-5) <= uint_t(4u)));
+        REQUIRE(bool(int_t(4) <= uint_t(4u)));
+#endif
+        REQUIRE(cmp_less_equal(int_t(4), int_t(5)));
+        REQUIRE(!cmp_less_equal(int_t(5), int_t(4)));
+        REQUIRE(cmp_less_equal(int_t(4), int_t(4)));
+        REQUIRE(cmp_less_equal(uint_t(4u), int_t(5)));
+        REQUIRE(!cmp_less_equal(uint_t(4u), int_t(-5)));
+        REQUIRE(!cmp_less_equal(uint_t(5u), int_t(4)));
+        REQUIRE(cmp_less_equal(uint_t(4u), int_t(4)));
+        REQUIRE(cmp_less_equal(int_t(4), uint_t(5u)));
+        REQUIRE(!cmp_less_equal(int_t(5), uint_t(4u)));
+        REQUIRE(cmp_less_equal(int_t(-5), uint_t(4u)));
+        REQUIRE(cmp_less_equal(int_t(4), uint_t(4u)));
 
         REQUIRE(bool(4 <= int_t(5)));
         REQUIRE(!(5 <= int_t(4)));
         REQUIRE(bool(4 <= int_t(4)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(4u <= int_t(5)));
+        REQUIRE(!(5u <= int_t(4)));
+        REQUIRE(bool(4u <= int_t(4)));
+        REQUIRE(bool(4 <= int_t(5)));
+        REQUIRE(!(5 <= int_t(4)));
+        REQUIRE(bool(4 <= int_t(4)));
+        REQUIRE(!(4 <= int_t(-4)));
+        REQUIRE(bool(4u <= int_t(5)));
+        REQUIRE(!(5u <= int_t(4)));
+        REQUIRE(bool(4u <= int_t(4)));
+        REQUIRE(bool(4 <= uint_t(5u)));
+        REQUIRE(!(5 <= uint_t(4u)));
+        REQUIRE(bool(4 <= uint_t(4u)));
+        REQUIRE(bool(-4 <= uint_t(4u)));
+#endif
+        REQUIRE(cmp_less_equal(4, int_t(5)));
+        REQUIRE(!cmp_less_equal(5, int_t(4)));
+        REQUIRE(cmp_less_equal(4, int_t(4)));
+        REQUIRE(!cmp_less_equal(4, int_t(-4)));
+        REQUIRE(cmp_less_equal(4u, int_t(5)));
+        REQUIRE(!cmp_less_equal(5u, int_t(4)));
+        REQUIRE(cmp_less_equal(4u, int_t(4)));
+        REQUIRE(cmp_less_equal(4, uint_t(5u)));
+        REQUIRE(!cmp_less_equal(5, uint_t(4u)));
+        REQUIRE(cmp_less_equal(4, uint_t(4u)));
+        REQUIRE(cmp_less_equal(-4, uint_t(4u)));
 
         REQUIRE(bool(int_t(4) <= 5));
         REQUIRE(!(int_t(5) <= 4));
         REQUIRE(bool(int_t(4) <= 4));
+        REQUIRE(bool(int_t(-4) <= 4));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(int_t(4) <= 5u));
+        REQUIRE(!(int_t(5) <= 4u));
+        REQUIRE(bool(int_t(4) <= 4u));
+        REQUIRE((int_t(4) <= 5));
+        REQUIRE(!(int_t(5) <= 4));
+        REQUIRE(bool(int_t(4) <= 4));
+        REQUIRE(bool(uint_t(4u) <= 5));
+        REQUIRE(!(uint_t(5u) <= 4));
+        REQUIRE(bool(uint_t(4u) <= 4));
+        REQUIRE(!(uint_t(4u) <= -4));
+        REQUIRE(bool(int_t(4) <= 5u));
+        REQUIRE(!(int_t(5) <= 4u));
+        REQUIRE(bool(int_t(4) <= 4u));
+        REQUIRE(bool(int_t(-4) <= 4u));
+#endif
+        REQUIRE(cmp_less_equal(int_t(4), 5));
+        REQUIRE(!cmp_less_equal(int_t(5), 4));
+        REQUIRE(cmp_less_equal(int_t(4), 4));
+        REQUIRE(cmp_less_equal(uint_t(4u), 5));
+        REQUIRE(!cmp_less_equal(uint_t(5u), 4));
+        REQUIRE(cmp_less_equal(uint_t(4u), 4));
+        REQUIRE(!cmp_less_equal(uint_t(4u), -4));
+        REQUIRE(cmp_less_equal(int_t(4), 5u));
+        REQUIRE(!cmp_less_equal(int_t(5), 4u));
+        REQUIRE(cmp_less_equal(int_t(4), 4u));
+        REQUIRE(cmp_less_equal(int_t(-4), 4u));
 
         // >
         REQUIRE(bool(int_t(5) > int_t(4)));
         REQUIRE(!(int_t(4) > int_t(5)));
         REQUIRE(!(int_t(5) > int_t(5)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(5u) > int_t(4)));
+        REQUIRE(bool(uint_t(5u) > int_t(-4)));
+        REQUIRE(!(uint_t(4u) > int_t(5)));
+        REQUIRE(!(uint_t(5u) > int_t(5)));
+        REQUIRE(bool(int_t(5) > uint_t(4u)));
+        REQUIRE(!(int_t(-5) > uint_t(4u)));
+        REQUIRE(!(int_t(4) > uint_t(5u)));
+        REQUIRE(!(int_t(5) > uint_t(5u)));
+#endif
+        REQUIRE(cmp_greater(int_t(5), int_t(4)));
+        REQUIRE(!cmp_greater(int_t(4), int_t(5)));
+        REQUIRE(!cmp_greater(int_t(5), int_t(5)));
+        REQUIRE(cmp_greater(uint_t(5u), int_t(4)));
+        REQUIRE(cmp_greater(uint_t(5u), int_t(-4)));
+        REQUIRE(!cmp_greater(uint_t(4u), int_t(5)));
+        REQUIRE(!cmp_greater(uint_t(5u), int_t(5)));
+        REQUIRE(cmp_greater(int_t(5), uint_t(4u)));
+        REQUIRE(!cmp_greater(int_t(-5), uint_t(4u)));
+        REQUIRE(!cmp_greater(int_t(4), uint_t(5u)));
+        REQUIRE(!cmp_greater(int_t(5), uint_t(5u)));
 
         REQUIRE(bool(5 > int_t(4)));
         REQUIRE(!(4 > int_t(5)));
         REQUIRE(!(5 > int_t(5)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(5u > int_t(4)));
+        REQUIRE(!(4u > int_t(5)));
+        REQUIRE(!(5u > int_t(5)));
+        REQUIRE(bool(5u > int_t(4)));
+        REQUIRE(bool(5u > int_t(-4)));
+        REQUIRE(!(4u > int_t(5)));
+        REQUIRE(!(5u > int_t(5)));
+        REQUIRE(bool(5 > uint_t(4u)));
+        REQUIRE(!(-5 > uint_t(4u)));
+        REQUIRE(!(4 > uint_t(5u)));
+        REQUIRE(!(5 > uint_t(5u)));
+#endif
+        REQUIRE(cmp_greater(5, int_t(4)));
+        REQUIRE(!cmp_greater(4, int_t(5)));
+        REQUIRE(!cmp_greater(5, int_t(5)));
+        REQUIRE(cmp_greater(5u, int_t(4)));
+        REQUIRE(cmp_greater(5u, int_t(-4)));
+        REQUIRE(!cmp_greater(4u, int_t(5)));
+        REQUIRE(!cmp_greater(5u, int_t(5)));
+        REQUIRE(cmp_greater(5, uint_t(4u)));
+        REQUIRE(!cmp_greater(-5, uint_t(4u)));
+        REQUIRE(!cmp_greater(4, uint_t(5u)));
+        REQUIRE(!cmp_greater(5, uint_t(5u)));
 
         REQUIRE(bool(int_t(5) > 4));
         REQUIRE(!(int_t(4) > 5));
         REQUIRE(!(int_t(5) > 5));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(5u) > 4));
+        REQUIRE(bool(uint_t(5u) > -4));
+        REQUIRE(!(uint_t(4u) > 5));
+        REQUIRE(!(uint_t(5u) > 5));
+        REQUIRE(bool(int_t(5) > 4u));
+        REQUIRE(!(int_t(-5) > 4u));
+        REQUIRE(!(int_t(4) > 5u));
+        REQUIRE(!(int_t(5) > 5u));
+#endif
+        REQUIRE(cmp_greater(int_t(5), 4));
+        REQUIRE(!cmp_greater(int_t(4), 5));
+        REQUIRE(!cmp_greater(int_t(5), 5));
+        REQUIRE(cmp_greater(uint_t(5u), 4));
+        REQUIRE(cmp_greater(uint_t(5u), -4));
+        REQUIRE(!cmp_greater(uint_t(4u), 5));
+        REQUIRE(!cmp_greater(uint_t(5u), 5));
+        REQUIRE(cmp_greater(int_t(5), 4u));
+        REQUIRE(!cmp_greater(int_t(-5), 4u));
+        REQUIRE(!cmp_greater(int_t(4), 5u));
+        REQUIRE(!cmp_greater(int_t(5), 5u));
 
         // >=
         REQUIRE(bool(int_t(5) >= int_t(4)));
         REQUIRE(!(int_t(4) >= int_t(5)));
         REQUIRE(bool(int_t(5) >= int_t(5)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(5u) >= int_t(4)));
+        REQUIRE(!(uint_t(4u) >= int_t(5)));
+        REQUIRE(bool(uint_t(4u) >= int_t(-5)));
+        REQUIRE(bool(uint_t(5u) >= int_t(5)));
+        REQUIRE(bool(int_t(5) >= uint_t(4u)));
+        REQUIRE(!(int_t(4) >= uint_t(5u)));
+        REQUIRE(bool(int_t(5) >= uint_t(5u)));
+        REQUIRE(!(int_t(-5) >= uint_t(5u)));
+#endif
+        REQUIRE(cmp_greater_equal(int_t(5), int_t(4)));
+        REQUIRE(!cmp_greater_equal(int_t(4), int_t(5)));
+        REQUIRE(cmp_greater_equal(int_t(5), int_t(5)));
+        REQUIRE(cmp_greater_equal(uint_t(5u), int_t(4)));
+        REQUIRE(!cmp_greater_equal(uint_t(4u), int_t(5)));
+        REQUIRE(cmp_greater_equal(uint_t(4u), int_t(-5)));
+        REQUIRE(cmp_greater_equal(uint_t(5u), int_t(5)));
+        REQUIRE(cmp_greater_equal(int_t(5), uint_t(4u)));
+        REQUIRE(!cmp_greater_equal(int_t(4), uint_t(5u)));
+        REQUIRE(cmp_greater_equal(int_t(5), uint_t(5u)));
+        REQUIRE(!cmp_greater_equal(int_t(-5), uint_t(5u)));
 
         REQUIRE(bool(5 >= int_t(4)));
         REQUIRE(!(4 >= int_t(5)));
         REQUIRE(bool(5 >= int_t(5)));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(5u >= int_t(4)));
+        REQUIRE(!(4u >= int_t(5)));
+        REQUIRE(bool(4u >= int_t(-5)));
+        REQUIRE(bool(5u >= int_t(5)));
+        REQUIRE(bool(5u >= int_t(-5)));
+        REQUIRE(bool(5 >= uint_t(4u)));
+        REQUIRE(!(4 >= uint_t(5u)));
+        REQUIRE(bool(5 >= uint_t(5u)));
+        REQUIRE(!(-5 >= uint_t(5u)));
+#endif
+        REQUIRE(cmp_greater_equal(5, int_t(4)));
+        REQUIRE(!cmp_greater_equal(4, int_t(5)));
+        REQUIRE(cmp_greater_equal(5, int_t(5)));
+        REQUIRE(cmp_greater_equal(5u, int_t(4)));
+        REQUIRE(!cmp_greater_equal(4u, int_t(5)));
+        REQUIRE(cmp_greater_equal(4u, int_t(-5)));
+        REQUIRE(cmp_greater_equal(5u, int_t(5)));
+        REQUIRE(cmp_greater_equal(5, uint_t(4u)));
+        REQUIRE(!cmp_greater_equal(4, uint_t(5u)));
+        REQUIRE(cmp_greater_equal(5, uint_t(5u)));
+        REQUIRE(!cmp_greater_equal(-5, uint_t(5u)));
 
         REQUIRE(bool(int_t(5) >= 4));
         REQUIRE(!(int_t(4) >= 5));
         REQUIRE(bool(int_t(5) >= 5));
+#ifdef TYPE_SAFE_USE_CONSTEXPR14
+        REQUIRE(bool(uint_t(5u) >= 4));
+        REQUIRE(!(uint_t(4u) >= 5));
+        REQUIRE(bool(uint_t(4u) >= -5));
+        REQUIRE(bool(uint_t(5u) >= 5));
+        REQUIRE(bool(int_t(5) >= 4u));
+        REQUIRE(!(int_t(-5) >= 4u));
+        REQUIRE(!(int_t(4) >= 5u));
+        REQUIRE(bool(int_t(5) >= 5u));
+#endif
+        REQUIRE(cmp_greater_equal(int_t(5), 4));
+        REQUIRE(!cmp_greater_equal(int_t(4), 5));
+        REQUIRE(cmp_greater_equal(int_t(5), 5));
+        REQUIRE(cmp_greater_equal(uint_t(5u), 4));
+        REQUIRE(!cmp_greater_equal(uint_t(4u), 5));
+        REQUIRE(cmp_greater_equal(uint_t(4u), -5));
+        REQUIRE(cmp_greater_equal(uint_t(5u), 5));
+        REQUIRE(cmp_greater_equal(int_t(5), 4u));
+        REQUIRE(!cmp_greater_equal(int_t(-5), 4u));
+        REQUIRE(!cmp_greater_equal(int_t(4), 5u));
+        REQUIRE(cmp_greater_equal(int_t(5), 5u));
     }
     SECTION("make_(un)signed")
     {

--- a/test/integer.cpp
+++ b/test/integer.cpp
@@ -219,124 +219,63 @@ TEST_CASE("integer")
         // ==
         REQUIRE(bool(int_t(4) == int_t(4)));
         REQUIRE(!(int_t(5) == int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(4u) == int_t(4)));
         REQUIRE(!(uint_t(5u) == int_t(4)));
         REQUIRE(!(uint_t(u32_max) == int_t(-1)));
         REQUIRE(bool(int_t(4) == uint_t(4u)));
         REQUIRE(!(int_t(5) == uint_t(4u)));
         REQUIRE(!(int_t(-1) == uint_t(u32_max)));
-#endif
-        REQUIRE(cmp_equal(int_t(4), int_t(4)));
-        REQUIRE(!cmp_equal(int_t(5), int_t(4)));
-        REQUIRE(cmp_equal(uint_t(4u), int_t(4)));
-        REQUIRE(!cmp_equal(uint_t(5u), int_t(4)));
-        REQUIRE(!cmp_equal(uint_t(u32_max), int_t(-1)));
-        REQUIRE(cmp_equal(int_t(4), uint_t(4u)));
-        REQUIRE(!cmp_equal(int_t(5), uint_t(4u)));
-        REQUIRE(!cmp_equal(int_t(-1), uint_t(u32_max)));
 
         REQUIRE(bool(4 == int_t(4)));
         REQUIRE(!(5 == int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(4u == int_t(4)));
         REQUIRE(!(5u == int_t(4)));
         REQUIRE(!(u32_max == int_t(-1)));
         REQUIRE(bool(4 == uint_t(4u)));
         REQUIRE(!(5 == uint_t(4u)));
         REQUIRE(!(-1 == uint_t(u32_max)));
-#endif
-        REQUIRE(cmp_equal(4, int_t(4)));
-        REQUIRE(!cmp_equal(5, int_t(4)));
-        REQUIRE(cmp_equal(4u, int_t(4)));
-        REQUIRE(!cmp_equal(5u, int_t(4)));
-        REQUIRE(!cmp_equal(u32_max, int_t(-1)));
-        REQUIRE(cmp_equal(4, uint_t(4u)));
-        REQUIRE(!cmp_equal(5, uint_t(4u)));
-        REQUIRE(!cmp_equal(-1, uint_t(u32_max)));
 
         REQUIRE(bool(int_t(4) == 4));
         REQUIRE(!(int_t(5) == 4));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(int_t(4) == 4u));
         REQUIRE(!(int_t(5) == 4u));
         REQUIRE(!(int_t(-1) == u32_max));
         REQUIRE(bool(uint_t(4u) == 4));
         REQUIRE(!(uint_t(5u) == 4));
         REQUIRE(!(uint_t(u32_max) == -1));
-#endif
-        REQUIRE(cmp_equal(int_t(4), 4));
-        REQUIRE(!cmp_equal(int_t(5), 4));
-        REQUIRE(cmp_equal(int_t(4), 4u));
-        REQUIRE(!cmp_equal(int_t(5), 4u));
-        REQUIRE(!cmp_equal(int_t(-1), u32_max));
-        REQUIRE(cmp_equal(uint_t(4u), 4));
-        REQUIRE(!cmp_equal(uint_t(5u), 4));
-        REQUIRE(!cmp_equal(uint_t(u32_max), -1));
 
         // !=
         REQUIRE(bool(int_t(5) != int_t(4)));
         REQUIRE(!(int_t(4) != int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(5u) != int_t(4)));
         REQUIRE(!(uint_t(4u) != int_t(4)));
         REQUIRE(bool(uint_t(u32_max) != int_t(-1)));
         REQUIRE(bool(int_t(5) != uint_t(4u)));
         REQUIRE(!(int_t(4) != uint_t(4u)));
         REQUIRE(bool(int_t(-1) != uint_t(u32_max)));
-#endif
-        REQUIRE(cmp_not_equal(int_t(5), int_t(4)));
-        REQUIRE(!cmp_not_equal(int_t(4), int_t(4)));
-        REQUIRE(cmp_not_equal(uint_t(5u), int_t(4)));
-        REQUIRE(!cmp_not_equal(uint_t(4u), int_t(4)));
-        REQUIRE(cmp_not_equal(uint_t(u32_max), int_t(-1)));
-        REQUIRE(cmp_not_equal(int_t(5), uint_t(4u)));
-        REQUIRE(!cmp_not_equal(int_t(4), uint_t(4u)));
-        REQUIRE(cmp_not_equal(int_t(-1), uint_t(u32_max)));
 
         REQUIRE(bool(5 != int_t(4)));
         REQUIRE(!(4 != int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(5u != int_t(4)));
         REQUIRE(!(4u != int_t(4)));
         REQUIRE(bool(u32_max != int_t(-1)));
         REQUIRE(bool(5 != uint_t(4u)));
         REQUIRE(!(4 != uint_t(4u)));
         REQUIRE(bool(-1 != uint_t(u32_max)));
-#endif
-        REQUIRE(cmp_not_equal(5, int_t(4)));
-        REQUIRE(!cmp_not_equal(4, int_t(4)));
-        REQUIRE(cmp_not_equal(5u, int_t(4)));
-        REQUIRE(!cmp_not_equal(4u, int_t(4)));
-        REQUIRE(cmp_not_equal(u32_max, int_t(-1)));
-        REQUIRE(cmp_not_equal(5, uint_t(4u)));
-        REQUIRE(!cmp_not_equal(4, uint_t(4u)));
-        REQUIRE(cmp_not_equal(-1, uint_t(u32_max)));
 
         REQUIRE(bool(int_t(5) != 4));
         REQUIRE(!(int_t(4) != 4));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(int_t(5) != 4u));
         REQUIRE(!(int_t(4) != 4u));
         REQUIRE(bool(int_t(-1) != u32_max));
         REQUIRE(bool(uint_t(5u) != 4));
         REQUIRE(!(uint_t(4u) != 4));
         REQUIRE(bool(uint_t(u32_max) != -1));
-#endif
-        REQUIRE(cmp_not_equal(int_t(5), 4));
-        REQUIRE(!cmp_not_equal(int_t(4), 4));
-        REQUIRE(cmp_not_equal(int_t(5), 4u));
-        REQUIRE(!cmp_not_equal(int_t(4), 4u));
-        REQUIRE(cmp_not_equal(int_t(-1), u32_max));
-        REQUIRE(cmp_not_equal(uint_t(5u), 4));
-        REQUIRE(!cmp_not_equal(uint_t(4u), 4));
-        REQUIRE(cmp_not_equal(uint_t(u32_max), -1));
 
         // <
         REQUIRE(bool(int_t(4) < int_t(5)));
         REQUIRE(!(int_t(5) < int_t(4)));
         REQUIRE(!(int_t(4) < int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(4u) < int_t(5)));
         REQUIRE(!bool(uint_t(4u) < int_t(-5)));
         REQUIRE(!(uint_t(5u) < int_t(4)));
@@ -345,23 +284,10 @@ TEST_CASE("integer")
         REQUIRE(bool(int_t(-4) < uint_t(5u)));
         REQUIRE(!(int_t(5) < uint_t(4u)));
         REQUIRE(!(int_t(4) < uint_t(4u)));
-#endif
-        REQUIRE(cmp_less(int_t(4), int_t(5)));
-        REQUIRE(!cmp_less(int_t(5), int_t(4)));
-        REQUIRE(!cmp_less(int_t(4), int_t(4)));
-        REQUIRE(cmp_less(uint_t(4u), int_t(5)));
-        REQUIRE(!cmp_less(uint_t(4u), int_t(-5)));
-        REQUIRE(!cmp_less(uint_t(5u), int_t(4)));
-        REQUIRE(!cmp_less(uint_t(4u), int_t(4)));
-        REQUIRE(cmp_less(int_t(4), uint_t(5u)));
-        REQUIRE(cmp_less(int_t(-4), uint_t(5u)));
-        REQUIRE(!cmp_less(int_t(5), uint_t(4u)));
-        REQUIRE(!cmp_less(int_t(4), uint_t(4u)));
 
         REQUIRE(bool(4 < int_t(5)));
         REQUIRE(!(5 < int_t(4)));
         REQUIRE(!(4 < int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(4u < int_t(5)));
         REQUIRE(!bool(4u < int_t(-5)));
         REQUIRE(!(5u < int_t(4)));
@@ -370,23 +296,10 @@ TEST_CASE("integer")
         REQUIRE(bool(-4 < uint_t(5u)));
         REQUIRE(!(5 < uint_t(4u)));
         REQUIRE(!(4 < uint_t(4u)));
-#endif
-        REQUIRE(cmp_less(4, int_t(5)));
-        REQUIRE(!cmp_less(5, int_t(4)));
-        REQUIRE(!cmp_less(4, int_t(4)));
-        REQUIRE(cmp_less(4u, int_t(5)));
-        REQUIRE(!cmp_less(4u, int_t(-5)));
-        REQUIRE(!cmp_less(5u, int_t(4)));
-        REQUIRE(!cmp_less(4u, int_t(4)));
-        REQUIRE(cmp_less(4, uint_t(5u)));
-        REQUIRE(cmp_less(-4, uint_t(5u)));
-        REQUIRE(!cmp_less(5, uint_t(4u)));
-        REQUIRE(!cmp_less(4, uint_t(4u)));
 
         REQUIRE(bool(int_t(4) < 5));
         REQUIRE(!(int_t(5) < 4));
         REQUIRE(!(int_t(4) < 4));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(int_t(4) < 5u));
         REQUIRE(!(int_t(5) < 4u));
         REQUIRE((int_t(-5) < 4u));
@@ -395,24 +308,11 @@ TEST_CASE("integer")
         REQUIRE(!bool(uint_t(4u) < -5));
         REQUIRE(!(uint_t(5u) < 4));
         REQUIRE(!(uint_t(4u) < 4));
-#endif
-        REQUIRE(cmp_less(int_t(4), 5));
-        REQUIRE(!cmp_less(int_t(5), 4));
-        REQUIRE(!cmp_less(int_t(4), 4));
-        REQUIRE(cmp_less(int_t(4), 5u));
-        REQUIRE(!cmp_less(int_t(5), 4u));
-        REQUIRE(cmp_less(int_t(-5), 4u));
-        REQUIRE(!cmp_less(int_t(4), 4u));
-        REQUIRE(cmp_less(uint_t(4u), 5));
-        REQUIRE(!cmp_less(uint_t(4u), -5));
-        REQUIRE(!cmp_less(uint_t(5u), 4));
-        REQUIRE(!cmp_less(uint_t(4u), 4));
 
         // <=
         REQUIRE(bool(int_t(4) <= int_t(5)));
         REQUIRE(!(int_t(5) <= int_t(4)));
         REQUIRE(bool(int_t(4) <= int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(4u) <= int_t(5)));
         REQUIRE(!(uint_t(4u) <= int_t(-5)));
         REQUIRE(!(uint_t(5u) <= int_t(4)));
@@ -421,23 +321,10 @@ TEST_CASE("integer")
         REQUIRE(!(int_t(5) <= uint_t(4u)));
         REQUIRE(bool(int_t(-5) <= uint_t(4u)));
         REQUIRE(bool(int_t(4) <= uint_t(4u)));
-#endif
-        REQUIRE(cmp_less_equal(int_t(4), int_t(5)));
-        REQUIRE(!cmp_less_equal(int_t(5), int_t(4)));
-        REQUIRE(cmp_less_equal(int_t(4), int_t(4)));
-        REQUIRE(cmp_less_equal(uint_t(4u), int_t(5)));
-        REQUIRE(!cmp_less_equal(uint_t(4u), int_t(-5)));
-        REQUIRE(!cmp_less_equal(uint_t(5u), int_t(4)));
-        REQUIRE(cmp_less_equal(uint_t(4u), int_t(4)));
-        REQUIRE(cmp_less_equal(int_t(4), uint_t(5u)));
-        REQUIRE(!cmp_less_equal(int_t(5), uint_t(4u)));
-        REQUIRE(cmp_less_equal(int_t(-5), uint_t(4u)));
-        REQUIRE(cmp_less_equal(int_t(4), uint_t(4u)));
 
         REQUIRE(bool(4 <= int_t(5)));
         REQUIRE(!(5 <= int_t(4)));
         REQUIRE(bool(4 <= int_t(4)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(4u <= int_t(5)));
         REQUIRE(!(5u <= int_t(4)));
         REQUIRE(bool(4u <= int_t(4)));
@@ -452,24 +339,11 @@ TEST_CASE("integer")
         REQUIRE(!(5 <= uint_t(4u)));
         REQUIRE(bool(4 <= uint_t(4u)));
         REQUIRE(bool(-4 <= uint_t(4u)));
-#endif
-        REQUIRE(cmp_less_equal(4, int_t(5)));
-        REQUIRE(!cmp_less_equal(5, int_t(4)));
-        REQUIRE(cmp_less_equal(4, int_t(4)));
-        REQUIRE(!cmp_less_equal(4, int_t(-4)));
-        REQUIRE(cmp_less_equal(4u, int_t(5)));
-        REQUIRE(!cmp_less_equal(5u, int_t(4)));
-        REQUIRE(cmp_less_equal(4u, int_t(4)));
-        REQUIRE(cmp_less_equal(4, uint_t(5u)));
-        REQUIRE(!cmp_less_equal(5, uint_t(4u)));
-        REQUIRE(cmp_less_equal(4, uint_t(4u)));
-        REQUIRE(cmp_less_equal(-4, uint_t(4u)));
 
         REQUIRE(bool(int_t(4) <= 5));
         REQUIRE(!(int_t(5) <= 4));
         REQUIRE(bool(int_t(4) <= 4));
         REQUIRE(bool(int_t(-4) <= 4));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(int_t(4) <= 5u));
         REQUIRE(!(int_t(5) <= 4u));
         REQUIRE(bool(int_t(4) <= 4u));
@@ -484,24 +358,11 @@ TEST_CASE("integer")
         REQUIRE(!(int_t(5) <= 4u));
         REQUIRE(bool(int_t(4) <= 4u));
         REQUIRE(bool(int_t(-4) <= 4u));
-#endif
-        REQUIRE(cmp_less_equal(int_t(4), 5));
-        REQUIRE(!cmp_less_equal(int_t(5), 4));
-        REQUIRE(cmp_less_equal(int_t(4), 4));
-        REQUIRE(cmp_less_equal(uint_t(4u), 5));
-        REQUIRE(!cmp_less_equal(uint_t(5u), 4));
-        REQUIRE(cmp_less_equal(uint_t(4u), 4));
-        REQUIRE(!cmp_less_equal(uint_t(4u), -4));
-        REQUIRE(cmp_less_equal(int_t(4), 5u));
-        REQUIRE(!cmp_less_equal(int_t(5), 4u));
-        REQUIRE(cmp_less_equal(int_t(4), 4u));
-        REQUIRE(cmp_less_equal(int_t(-4), 4u));
 
         // >
         REQUIRE(bool(int_t(5) > int_t(4)));
         REQUIRE(!(int_t(4) > int_t(5)));
         REQUIRE(!(int_t(5) > int_t(5)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(5u) > int_t(4)));
         REQUIRE(bool(uint_t(5u) > int_t(-4)));
         REQUIRE(!(uint_t(4u) > int_t(5)));
@@ -510,23 +371,10 @@ TEST_CASE("integer")
         REQUIRE(!(int_t(-5) > uint_t(4u)));
         REQUIRE(!(int_t(4) > uint_t(5u)));
         REQUIRE(!(int_t(5) > uint_t(5u)));
-#endif
-        REQUIRE(cmp_greater(int_t(5), int_t(4)));
-        REQUIRE(!cmp_greater(int_t(4), int_t(5)));
-        REQUIRE(!cmp_greater(int_t(5), int_t(5)));
-        REQUIRE(cmp_greater(uint_t(5u), int_t(4)));
-        REQUIRE(cmp_greater(uint_t(5u), int_t(-4)));
-        REQUIRE(!cmp_greater(uint_t(4u), int_t(5)));
-        REQUIRE(!cmp_greater(uint_t(5u), int_t(5)));
-        REQUIRE(cmp_greater(int_t(5), uint_t(4u)));
-        REQUIRE(!cmp_greater(int_t(-5), uint_t(4u)));
-        REQUIRE(!cmp_greater(int_t(4), uint_t(5u)));
-        REQUIRE(!cmp_greater(int_t(5), uint_t(5u)));
 
         REQUIRE(bool(5 > int_t(4)));
         REQUIRE(!(4 > int_t(5)));
         REQUIRE(!(5 > int_t(5)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(5u > int_t(4)));
         REQUIRE(!(4u > int_t(5)));
         REQUIRE(!(5u > int_t(5)));
@@ -538,23 +386,10 @@ TEST_CASE("integer")
         REQUIRE(!(-5 > uint_t(4u)));
         REQUIRE(!(4 > uint_t(5u)));
         REQUIRE(!(5 > uint_t(5u)));
-#endif
-        REQUIRE(cmp_greater(5, int_t(4)));
-        REQUIRE(!cmp_greater(4, int_t(5)));
-        REQUIRE(!cmp_greater(5, int_t(5)));
-        REQUIRE(cmp_greater(5u, int_t(4)));
-        REQUIRE(cmp_greater(5u, int_t(-4)));
-        REQUIRE(!cmp_greater(4u, int_t(5)));
-        REQUIRE(!cmp_greater(5u, int_t(5)));
-        REQUIRE(cmp_greater(5, uint_t(4u)));
-        REQUIRE(!cmp_greater(-5, uint_t(4u)));
-        REQUIRE(!cmp_greater(4, uint_t(5u)));
-        REQUIRE(!cmp_greater(5, uint_t(5u)));
 
         REQUIRE(bool(int_t(5) > 4));
         REQUIRE(!(int_t(4) > 5));
         REQUIRE(!(int_t(5) > 5));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(5u) > 4));
         REQUIRE(bool(uint_t(5u) > -4));
         REQUIRE(!(uint_t(4u) > 5));
@@ -563,24 +398,11 @@ TEST_CASE("integer")
         REQUIRE(!(int_t(-5) > 4u));
         REQUIRE(!(int_t(4) > 5u));
         REQUIRE(!(int_t(5) > 5u));
-#endif
-        REQUIRE(cmp_greater(int_t(5), 4));
-        REQUIRE(!cmp_greater(int_t(4), 5));
-        REQUIRE(!cmp_greater(int_t(5), 5));
-        REQUIRE(cmp_greater(uint_t(5u), 4));
-        REQUIRE(cmp_greater(uint_t(5u), -4));
-        REQUIRE(!cmp_greater(uint_t(4u), 5));
-        REQUIRE(!cmp_greater(uint_t(5u), 5));
-        REQUIRE(cmp_greater(int_t(5), 4u));
-        REQUIRE(!cmp_greater(int_t(-5), 4u));
-        REQUIRE(!cmp_greater(int_t(4), 5u));
-        REQUIRE(!cmp_greater(int_t(5), 5u));
 
         // >=
         REQUIRE(bool(int_t(5) >= int_t(4)));
         REQUIRE(!(int_t(4) >= int_t(5)));
         REQUIRE(bool(int_t(5) >= int_t(5)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(5u) >= int_t(4)));
         REQUIRE(!(uint_t(4u) >= int_t(5)));
         REQUIRE(bool(uint_t(4u) >= int_t(-5)));
@@ -589,23 +411,10 @@ TEST_CASE("integer")
         REQUIRE(!(int_t(4) >= uint_t(5u)));
         REQUIRE(bool(int_t(5) >= uint_t(5u)));
         REQUIRE(!(int_t(-5) >= uint_t(5u)));
-#endif
-        REQUIRE(cmp_greater_equal(int_t(5), int_t(4)));
-        REQUIRE(!cmp_greater_equal(int_t(4), int_t(5)));
-        REQUIRE(cmp_greater_equal(int_t(5), int_t(5)));
-        REQUIRE(cmp_greater_equal(uint_t(5u), int_t(4)));
-        REQUIRE(!cmp_greater_equal(uint_t(4u), int_t(5)));
-        REQUIRE(cmp_greater_equal(uint_t(4u), int_t(-5)));
-        REQUIRE(cmp_greater_equal(uint_t(5u), int_t(5)));
-        REQUIRE(cmp_greater_equal(int_t(5), uint_t(4u)));
-        REQUIRE(!cmp_greater_equal(int_t(4), uint_t(5u)));
-        REQUIRE(cmp_greater_equal(int_t(5), uint_t(5u)));
-        REQUIRE(!cmp_greater_equal(int_t(-5), uint_t(5u)));
 
         REQUIRE(bool(5 >= int_t(4)));
         REQUIRE(!(4 >= int_t(5)));
         REQUIRE(bool(5 >= int_t(5)));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(5u >= int_t(4)));
         REQUIRE(!(4u >= int_t(5)));
         REQUIRE(bool(4u >= int_t(-5)));
@@ -615,23 +424,10 @@ TEST_CASE("integer")
         REQUIRE(!(4 >= uint_t(5u)));
         REQUIRE(bool(5 >= uint_t(5u)));
         REQUIRE(!(-5 >= uint_t(5u)));
-#endif
-        REQUIRE(cmp_greater_equal(5, int_t(4)));
-        REQUIRE(!cmp_greater_equal(4, int_t(5)));
-        REQUIRE(cmp_greater_equal(5, int_t(5)));
-        REQUIRE(cmp_greater_equal(5u, int_t(4)));
-        REQUIRE(!cmp_greater_equal(4u, int_t(5)));
-        REQUIRE(cmp_greater_equal(4u, int_t(-5)));
-        REQUIRE(cmp_greater_equal(5u, int_t(5)));
-        REQUIRE(cmp_greater_equal(5, uint_t(4u)));
-        REQUIRE(!cmp_greater_equal(4, uint_t(5u)));
-        REQUIRE(cmp_greater_equal(5, uint_t(5u)));
-        REQUIRE(!cmp_greater_equal(-5, uint_t(5u)));
 
         REQUIRE(bool(int_t(5) >= 4));
         REQUIRE(!(int_t(4) >= 5));
         REQUIRE(bool(int_t(5) >= 5));
-#ifdef TYPE_SAFE_USE_CONSTEXPR14
         REQUIRE(bool(uint_t(5u) >= 4));
         REQUIRE(!(uint_t(4u) >= 5));
         REQUIRE(bool(uint_t(4u) >= -5));
@@ -640,18 +436,6 @@ TEST_CASE("integer")
         REQUIRE(!(int_t(-5) >= 4u));
         REQUIRE(!(int_t(4) >= 5u));
         REQUIRE(bool(int_t(5) >= 5u));
-#endif
-        REQUIRE(cmp_greater_equal(int_t(5), 4));
-        REQUIRE(!cmp_greater_equal(int_t(4), 5));
-        REQUIRE(cmp_greater_equal(int_t(5), 5));
-        REQUIRE(cmp_greater_equal(uint_t(5u), 4));
-        REQUIRE(!cmp_greater_equal(uint_t(4u), 5));
-        REQUIRE(cmp_greater_equal(uint_t(4u), -5));
-        REQUIRE(cmp_greater_equal(uint_t(5u), 5));
-        REQUIRE(cmp_greater_equal(int_t(5), 4u));
-        REQUIRE(!cmp_greater_equal(int_t(-5), 4u));
-        REQUIRE(!cmp_greater_equal(int_t(4), 5u));
-        REQUIRE(cmp_greater_equal(int_t(5), 5u));
     }
     SECTION("make_(un)signed")
     {


### PR DESCRIPTION
This PR implements unsafe integer comparison - and makes it safe.

The PR will close #80. The interface is modeled after [P0586R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0586r2.html) and the implementation follows the reference implementation from [cppreference](https://en.cppreference.com/w/cpp/utility/intcmp).

With a C++11 compiler, one can compare integers as:
``` C++
#include <type_safe/integer.hpp>
#include <cassert>

int main()
{
  using i32 = type_safe::integer<int>;
  using u32 = type_safe::integer<unsigned int>;

  const i32 a(-1);
  const u32 b(1u);

  assert(type_safe::cmp_less(a, b));

  return 0;
}
```

With a C++14 compliant compiler, the compare functions are constexpr and I have additionally overloaded the comparison operators for convenience:
```C++
#include <type_safe/integer.hpp>

int main()
{
  using i32 = type_safe::integer<int>;
  using u32 = type_safe::integer<unsigned int>;

  constexpr i32 a(-1);
  constexpr u32 b(1u);

  static_assert(type_safe::cmp_less(a, b));
  static_assert(a < b);

  return 0;
}
```

Any thoughts on the implementation?