### PR TITLE
using namespace type_safe in test cases causes clashes

### DIFF
--- a/test/index.cpp
+++ b/test/index.cpp
@@ -6,7 +6,8 @@
 
 #include <catch.hpp>
 
-using namespace type_safe;
+using type_safe::difference_t;
+using type_safe::index_t;
 
 TEST_CASE("index_t")
 {

--- a/test/optional.cpp
+++ b/test/optional.cpp
@@ -9,7 +9,10 @@
 
 #include "debugger_type.hpp"
 
-using namespace type_safe;
+using type_safe::optional;
+using type_safe::optional_ref;
+using type_safe::make_optional;
+using type_safe::nullopt;
 
 TEST_CASE("optional")
 {

--- a/test/optional_ref.cpp
+++ b/test/optional_ref.cpp
@@ -8,7 +8,14 @@
 
 #include "debugger_type.hpp"
 
-using namespace type_safe;
+using type_safe::optional;
+using type_safe::object_ref;
+using type_safe::optional_ref;
+using type_safe::optional_xvalue_ref;
+using type_safe::opt_ref;
+using type_safe::opt_cref;
+using type_safe::opt_xref;
+using type_safe::ref;
 
 template <typename A, typename B, typename Value>
 void test_optional_ref_conversion(Value)

--- a/test/reference.cpp
+++ b/test/reference.cpp
@@ -9,7 +9,12 @@
 
 #include "debugger_type.hpp"
 
-using namespace type_safe;
+using type_safe::array_ref;
+using type_safe::function_ref;
+using type_safe::object_ref;
+using type_safe::cref;
+using type_safe::ref;
+using type_safe::xvalue_ref;
 
 template <typename T>
 void check_object_ref(const object_ref<T>& ref, const debugger_type& value)

--- a/test/variant.cpp
+++ b/test/variant.cpp
@@ -8,7 +8,13 @@
 
 #include "debugger_type.hpp"
 
-using namespace type_safe;
+using type_safe::fallback_variant;
+using type_safe::nullvar;
+using type_safe::nullvar_t;
+using type_safe::tagged_union;
+using type_safe::union_type;
+using type_safe::variant;
+using type_safe::variant_type;
 
 // use optional variant to be able to test all functions
 // test policies separately

--- a/test/visitor.cpp
+++ b/test/visitor.cpp
@@ -6,7 +6,10 @@
 
 #include <catch.hpp>
 
-using namespace type_safe;
+using type_safe::nullopt_t;
+using type_safe::nullvar_t;
+using type_safe::optional;
+using type_safe::variant;
 
 TEST_CASE("visit optional")
 {


### PR DESCRIPTION
Fixes foonathan/type_safe#138