### PR TITLE
Update Catch 2.13.3 -> 2.13.10

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp)
     file(DOWNLOAD
-         https://github.com/catchorg/Catch2/releases/download/v2.13.3/catch.hpp
+         https://github.com/catchorg/Catch2/releases/download/v2.13.10/catch.hpp
          ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp
          STATUS status
          LOG log)


### PR DESCRIPTION
I was trying to compile everything C++23 and 2.13.3 headers have issues
Note 2.13.10 is the latest in the version 2 series