### PR TITLE
Prefer `VCToolsInstallDir` over `CMAKE_CXX_COMPILER` to locate std.ixx.

### DIFF
--- a/test_std_module/CMakeLists.txt
+++ b/test_std_module/CMakeLists.txt
@@ -8,7 +8,12 @@ target_include_directories(type_safe_test_std_module PUBLIC ${CMAKE_CURRENT_SOUR
 
 # Hopefully MS will provide a better/automatic/IJW way to use the standard library module, in other words "import std;" should just work
 if( MSVC )
-    # We use a path relative to the compiler location which should be stable and avoid VS upgrade/version/preview install location issues
-    cmake_path(GET CMAKE_CXX_COMPILER PARENT_PATH  CompilerDir)
-    target_sources(type_safe PUBLIC "${CompilerDir}/../../../modules/std.ixx" )
+    # Try to find "VCToolsInstallDir" from the environment variable, then look for "std.ixx" according to its path
+    if (DEFINED ENV{VCToolsInstallDir} AND EXISTS $ENV{VCToolsInstallDir} AND EXISTS $ENV{VCToolsInstallDir}modules/std.ixx)
+        target_sources(type_safe PUBLIC "$ENV{VCToolsInstallDir}modules/std.ixx")
+    else ()
+        # We use a path relative to the compiler location which should be stable and avoid VS upgrade/version/preview install location issues
+        cmake_path(GET CMAKE_CXX_COMPILER PARENT_PATH  CompilerDir)
+        target_sources(type_safe PUBLIC "${CompilerDir}/../../../modules/std.ixx")
+    endif (DEFINED ENV{VCToolsInstallDir} AND EXISTS $ENV{VCToolsInstallDir} AND EXISTS $ENV{VCToolsInstallDir}modules/std.ixx)
 endif()


### PR DESCRIPTION
Basically based on commit #147, but with a more "elegant" way of getting std.ixx.