### PR TITLE
Change cmake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is subject to the license terms in the LICENSE file
 # found in the top-level directory of this distribution.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(TYPE_SAFE)
 


### PR DESCRIPTION
Change cmake minimum version to 3.5 to work after 3.27 versions of cmake.

log with cmake 3.27.6:
Compatibility with CMake < 3.5 will be removed from a future version of CMake.